### PR TITLE
feat: NetworkClient 1차 설계 및 구현

### DIFF
--- a/Cheffi.xcodeproj/project.pbxproj
+++ b/Cheffi.xcodeproj/project.pbxproj
@@ -35,6 +35,11 @@
 		549B1FAC2C0607C9005C9432 /* CheffiUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 549B1FAB2C0607C9005C9432 /* CheffiUITestsLaunchTests.swift */; };
 		549B1FD52C0618D7005C9432 /* FontExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 549B1FD42C0618D7005C9432 /* FontExtension.swift */; };
 		549B1FDB2C061CE3005C9432 /* ColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 549B1FDA2C061CE3005C9432 /* ColorExtension.swift */; };
+		A611D9D12C187D6500ABF38C /* EndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = A611D9D02C187D6500ABF38C /* EndPoint.swift */; };
+		A611D9D32C187D7800ABF38C /* RestRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A611D9D22C187D7800ABF38C /* RestRouter.swift */; };
+		A611D9D52C187D8400ABF38C /* NetworkClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A611D9D42C187D8400ABF38C /* NetworkClient.swift */; };
+		A611D9D72C187DBC00ABF38C /* NetworkRetrier.swift in Sources */ = {isa = PBXBuildFile; fileRef = A611D9D62C187DBC00ABF38C /* NetworkRetrier.swift */; };
+		A611D9DB2C187F6000ABF38C /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = A611D9DA2C187F6000ABF38C /* Alamofire */; };
 		A67677F32C1738EF0089A269 /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = A67677F22C1738EF0089A269 /* AppEnvironment.swift */; };
 /* End PBXBuildFile section */
 
@@ -87,6 +92,10 @@
 		549B1FD42C0618D7005C9432 /* FontExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontExtension.swift; sourceTree = "<group>"; };
 		549B1FD62C061A68005C9432 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		549B1FDA2C061CE3005C9432 /* ColorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorExtension.swift; sourceTree = "<group>"; };
+		A611D9D02C187D6500ABF38C /* EndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndPoint.swift; sourceTree = "<group>"; };
+		A611D9D22C187D7800ABF38C /* RestRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestRouter.swift; sourceTree = "<group>"; };
+		A611D9D42C187D8400ABF38C /* NetworkClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkClient.swift; sourceTree = "<group>"; };
+		A611D9D62C187DBC00ABF38C /* NetworkRetrier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkRetrier.swift; sourceTree = "<group>"; };
 		A67677E92C1730C60089A269 /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		A67677F22C1738EF0089A269 /* AppEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEnvironment.swift; sourceTree = "<group>"; };
 		A67677F62C1740230089A269 /* Secrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
@@ -99,6 +108,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				54073B802C0CBC6500597973 /* ComposableArchitecture in Frameworks */,
+				A611D9DB2C187F6000ABF38C /* Alamofire in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -199,6 +209,10 @@
 			isa = PBXGroup;
 			children = (
 				548BC0652C086B1800A73F66 /* Dummy.swift */,
+				A611D9D02C187D6500ABF38C /* EndPoint.swift */,
+				A611D9D22C187D7800ABF38C /* RestRouter.swift */,
+				A611D9D42C187D8400ABF38C /* NetworkClient.swift */,
+				A611D9D62C187DBC00ABF38C /* NetworkRetrier.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -246,6 +260,7 @@
 				549B1F9E2C0607C9005C9432 /* CheffiTests */,
 				549B1FA82C0607C9005C9432 /* CheffiUITests */,
 				549B1F8C2C0607C7005C9432 /* Products */,
+				A611D9D92C187F6000ABF38C /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -318,6 +333,13 @@
 			path = Extensions;
 			sourceTree = "<group>";
 		};
+		A611D9D92C187F6000ABF38C /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		A67677F82C1740790089A269 /* Environment */ = {
 			isa = PBXGroup;
 			children = (
@@ -346,6 +368,7 @@
 			name = Cheffi;
 			packageProductDependencies = (
 				54073B7F2C0CBC6500597973 /* ComposableArchitecture */,
+				A611D9DA2C187F6000ABF38C /* Alamofire */,
 			);
 			productName = Cheffi;
 			productReference = 549B1F8B2C0607C7005C9432 /* Cheffi.app */;
@@ -421,6 +444,7 @@
 			mainGroup = 549B1F822C0607C7005C9432;
 			packageReferences = (
 				54073B7E2C0CBC6500597973 /* XCRemoteSwiftPackageReference "swift-composable-architecture" */,
+				A611D9D82C187F5600ABF38C /* XCRemoteSwiftPackageReference "Alamofire" */,
 			);
 			productRefGroup = 549B1F8C2C0607C7005C9432 /* Products */;
 			projectDirPath = "";
@@ -480,12 +504,16 @@
 				549B1F8F2C0607C7005C9432 /* CheffiApp.swift in Sources */,
 				54073B882C0D913800597973 /* NavigationBarFeature.swift in Sources */,
 				543F0AE42C10263100DFBDB1 /* HomeCheffiStoryView.swift in Sources */,
+				A611D9D52C187D8400ABF38C /* NetworkClient.swift in Sources */,
+				A611D9D12C187D6500ABF38C /* EndPoint.swift in Sources */,
 				54073B8C2C0D98E500597973 /* PlaceCell.swift in Sources */,
 				543F0AE62C10264800DFBDB1 /* HomeCheffiStoryFeature.swift in Sources */,
+				A611D9D32C187D7800ABF38C /* RestRouter.swift in Sources */,
 				549B1FDB2C061CE3005C9432 /* ColorExtension.swift in Sources */,
 				54073B6C2C0C474200597973 /* ImageExtension.swift in Sources */,
 				54073B832C0D906300597973 /* HomePopularFeature.swift in Sources */,
 				54073B8A2C0D932D00597973 /* HomePopularView.swift in Sources */,
+				A611D9D72C187DBC00ABF38C /* NetworkRetrier.swift in Sources */,
 				A67677F32C1738EF0089A269 /* AppEnvironment.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -844,6 +872,14 @@
 				version = 1.10.0;
 			};
 		};
+		A611D9D82C187F5600ABF38C /* XCRemoteSwiftPackageReference "Alamofire" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Alamofire/Alamofire.git";
+			requirement = {
+				kind = exactVersion;
+				version = 5.9.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -851,6 +887,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 54073B7E2C0CBC6500597973 /* XCRemoteSwiftPackageReference "swift-composable-architecture" */;
 			productName = ComposableArchitecture;
+		};
+		A611D9DA2C187F6000ABF38C /* Alamofire */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A611D9D82C187F5600ABF38C /* XCRemoteSwiftPackageReference "Alamofire" */;
+			productName = Alamofire;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Cheffi.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Cheffi.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "81d703dd6e7ef361d922e4159d56e99fa7337762368097761b4ba0ff022b4d31",
+  "originHash" : "e3e660a51fe05b86839b49a57f81b3c1f33c681cdb7ebfe8149ca83f75226934",
   "pins" : [
+    {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire.git",
+      "state" : {
+        "revision" : "723fa5a6c65812aec4a0d7cc432ee198883b6e00",
+        "version" : "5.9.0"
+      }
+    },
     {
       "identity" : "combine-schedulers",
       "kind" : "remoteSourceControl",

--- a/Cheffi/Application/Resource/Info.plist
+++ b/Cheffi/Application/Resource/Info.plist
@@ -4,6 +4,11 @@
 <dict>
 	<key>BASE_URL</key>
 	<string>$(BASE_URL)</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>UIAppFonts</key>
 	<array>
 		<string>SUIT-Bold.otf</string>

--- a/Cheffi/Network/EndPoint.swift
+++ b/Cheffi/Network/EndPoint.swift
@@ -1,0 +1,39 @@
+//
+//  EndPoint.swift
+//  Cheffi
+//
+//  Created by 이서준 on 6/6/24.
+//
+
+import Foundation
+import Alamofire
+
+protocol EndPoint: URLRequestConvertible {
+    var baseURL: String { get }
+    var path: String { get }
+    var headers: HTTPHeaders { get }
+    var parameters: Parameters { get }
+    var method: HTTPMethod { get }
+}
+
+extension EndPoint {
+    func asURLRequest() throws -> URLRequest {
+        guard let url = URL(string: baseURL.appending(path)) else {
+            throw AFError.createURLRequestFailed(error: URLError(.badURL))
+        }
+        
+        var urlRequest = try URLRequest(url: url, method: method)
+        urlRequest.headers = headers
+
+        switch method {
+        case .get:
+            urlRequest = try URLEncoding.queryString
+                .encode(urlRequest, with: parameters)
+        default:
+            urlRequest = try JSONEncoding(options: .prettyPrinted)
+                .encode(urlRequest, with: parameters)
+        }
+        
+        return urlRequest
+    }
+}

--- a/Cheffi/Network/NetworkClient.swift
+++ b/Cheffi/Network/NetworkClient.swift
@@ -1,0 +1,46 @@
+//
+//  NetworkClient.swift
+//  Cheffi
+//
+//  Created by 이서준 on 6/6/24.
+//
+
+import Foundation
+import Combine
+import Alamofire
+
+protocol NetworkClientable {
+    var session: Session { get }
+    var queue: DispatchQueue { get }
+    
+    func request<Value: Codable>(_ endPoint: RestRouter) -> AnyPublisher<Value, AFError>
+}
+
+final class NetworkClient: NetworkClientable {
+    
+    let session: Session
+    let queue: DispatchQueue
+    
+    init(
+        session: Session = Session.default,
+        queue: DispatchQueue = DispatchQueue(
+            label: "network.queue",
+            qos: .userInitiated,
+            attributes: .concurrent
+        )
+    ) {
+        self.session = session
+        self.queue = queue
+    }
+    
+    func request<Value: Codable>(_ endPoint: RestRouter) -> AnyPublisher<Value, AFError> {
+        return session.request(endPoint)
+            .validate()
+            // TODO: Progress 핸들링 -> Loading indicator 표시
+            .publishDecodable(type: Value.self)
+            .value()
+            .subscribe(on: queue)
+            .receive(on: DispatchQueue.main)
+            .eraseToAnyPublisher()
+    }
+}

--- a/Cheffi/Network/NetworkRetrier.swift
+++ b/Cheffi/Network/NetworkRetrier.swift
@@ -1,0 +1,42 @@
+//
+//  NetworkRetrier.swift
+//  Cheffi
+//
+//  Created by 이서준 on 6/6/24.
+//
+
+import Foundation
+import Combine
+import Alamofire
+
+final class NetworkRetrier: RequestRetrier {
+    
+    private var limit: Int
+    private var delay: TimeInterval
+    
+    init(limit: Int, delay: TimeInterval) {
+        self.limit = limit
+        self.delay = delay
+    }
+    
+    func retry(
+        _ request: Request,
+        for session: Session,
+        dueTo error: any Error,
+        completion: @escaping (RetryResult) -> Void
+    ) {
+        guard request.retryCount < limit else {
+            completion(.doNotRetry)
+            return
+        }
+        
+        guard let statusCode = request.response?.statusCode else {
+            completion(.doNotRetry)
+            return
+        }
+        
+        // TODO: 재시도 불가능 케이스 수집
+        // ex) 접근 권한 없음, 토큰 만료 등
+    }
+    
+}

--- a/Cheffi/Network/RestRouter.swift
+++ b/Cheffi/Network/RestRouter.swift
@@ -1,0 +1,68 @@
+//
+//  RestRouter.swift
+//  Cheffi
+//
+//  Created by 이서준 on 6/7/24.
+//
+
+import Foundation
+import Alamofire
+
+enum RestRouter {
+    case testUpload
+    case testSessionIssue
+    case testAuth(String)
+}
+
+extension RestRouter: EndPoint {
+    var baseURL: String {
+        do {
+            return try AppEnvironment.baseURL.getValue()
+        } catch {
+            return ""
+        }
+    }
+    
+    var path: String {
+        return fetchPath()
+    }
+    
+    var headers: HTTPHeaders {
+        return [
+            .contentType("application/json")
+        ]
+    }
+    
+    var parameters: Parameters {
+        let mirror = Mirror(reflecting: self)
+        
+        guard let (_, value) = mirror.children.first else {
+            return [:]
+        }
+        
+        return value as? [String: Codable] ?? [:]
+    }
+    
+    var method: HTTPMethod {
+        switch self {
+        case .testUpload:
+            return .post
+        case .testSessionIssue, .testAuth:
+            return .get
+        }
+    }
+}
+ 
+extension RestRouter {
+    // TODO: 코드 길이가 길어져서 가독성에 문제가 생길 경우 파일 분리하기
+    func fetchPath() -> String {
+        switch self {
+        case .testUpload:
+            return "/test/upload"
+        case .testSessionIssue:
+            return "/test/session/issue"
+        case .testAuth:
+            return "/test/auth"
+        }
+    }
+}


### PR DESCRIPTION
- EndPoint: API 요청을 위한 EndPoint 프로토콜이 구현되어있습니다.
- RestRouter: EndPoint를 채택, Cheffi API 요청에 필요한 데이터가 구현되어있습니다.
- NetworkClient: RestRouter를 파라미터로 받아 request를 요청하는 코어입니다.

### dependency
[Cheffi-iOS-Settings](https://github.com/Cheffi-GitHub/Cheffi-iOS-Settings) 비공개 레포지토리 빌드 환경이 필요합니다.