### PR TITLE
Feat/review detail

### DIFF
--- a/Cheffi.xcodeproj/project.pbxproj
+++ b/Cheffi.xcodeproj/project.pbxproj
@@ -184,10 +184,10 @@
 			isa = PBXGroup;
 			children = (
 				54073B7C2C0C564700597973 /* HomeView.swift */,
-				54DF6D972C1D60EB0031E95B /* CheffiPlace */,
 				54073B862C0D90B400597973 /* NavigationBar */,
 				54073B812C0D904200597973 /* Popular */,
 				543F0AE22C10261B00DFBDB1 /* CheffiStory */,
+				54DF6D972C1D60EB0031E95B /* CheffiPlace */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -776,7 +776,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -834,7 +834,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
@@ -863,7 +863,7 @@
 				INFOPLIST_KEY_UIStatusBarStyle = "";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -900,7 +900,7 @@
 				INFOPLIST_KEY_UIStatusBarStyle = "";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Cheffi.xcodeproj/project.pbxproj
+++ b/Cheffi.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		54073B8C2C0D98E500597973 /* PlaceCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54073B8B2C0D98E400597973 /* PlaceCell.swift */; };
 		540BE9B02C22C607009180AE /* ReviewDetailFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 540BE9AF2C22C607009180AE /* ReviewDetailFeature.swift */; };
 		540BE9B42C231036009180AE /* WriterRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 540BE9B32C231036009180AE /* WriterRow.swift */; };
+		541930492C3D49640080CA57 /* AllReviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 541930482C3D49640080CA57 /* AllReviewView.swift */; };
+		5419304B2C3D497D0080CA57 /* AllReviewFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5419304A2C3D497D0080CA57 /* AllReviewFeature.swift */; };
 		543F0AE42C10263100DFBDB1 /* HomeCheffiStoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 543F0AE32C10263100DFBDB1 /* HomeCheffiStoryView.swift */; };
 		543F0AE62C10264800DFBDB1 /* HomeCheffiStoryFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 543F0AE52C10264800DFBDB1 /* HomeCheffiStoryFeature.swift */; };
 		544BB7672C168F8400BD43E0 /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 544BB7662C168F8400BD43E0 /* MainTabView.swift */; };
@@ -96,6 +98,8 @@
 		540BE9AF2C22C607009180AE /* ReviewDetailFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDetailFeature.swift; sourceTree = "<group>"; };
 		540BE9B12C22C853009180AE /* ScrollViewOffset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollViewOffset.swift; sourceTree = "<group>"; };
 		540BE9B32C231036009180AE /* WriterRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriterRow.swift; sourceTree = "<group>"; };
+		541930482C3D49640080CA57 /* AllReviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllReviewView.swift; sourceTree = "<group>"; };
+		5419304A2C3D497D0080CA57 /* AllReviewFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllReviewFeature.swift; sourceTree = "<group>"; };
 		543F0AE32C10263100DFBDB1 /* HomeCheffiStoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCheffiStoryView.swift; sourceTree = "<group>"; };
 		543F0AE52C10264800DFBDB1 /* HomeCheffiStoryFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCheffiStoryFeature.swift; sourceTree = "<group>"; };
 		544BB7662C168F8400BD43E0 /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
@@ -210,6 +214,15 @@
 			path = NavigationBar;
 			sourceTree = "<group>";
 		};
+		541930472C3D49550080CA57 /* AllReviewView */ = {
+			isa = PBXGroup;
+			children = (
+				541930482C3D49640080CA57 /* AllReviewView.swift */,
+				5419304A2C3D497D0080CA57 /* AllReviewFeature.swift */,
+			);
+			path = AllReviewView;
+			sourceTree = "<group>";
+		};
 		543F0AE22C10261B00DFBDB1 /* CheffiStory */ = {
 			isa = PBXGroup;
 			children = (
@@ -306,6 +319,7 @@
 				A6F5E6CF2C2065420053C2E8 /* LoginView */,
 				549B1F902C0607C7005C9432 /* ContentView.swift */,
 				548FC68A2C2177C1003866A9 /* Review */,
+				541930472C3D49550080CA57 /* AllReviewView */,
 			);
 			path = Feature;
 			sourceTree = "<group>";
@@ -648,6 +662,7 @@
 				A6F5E6ED2C246A750053C2E8 /* KakaoLoginHandler.swift in Sources */,
 				54073B7D2C0C564700597973 /* HomeView.swift in Sources */,
 				548FC68C2C2177E8003866A9 /* ReviewDetailView.swift in Sources */,
+				541930492C3D49640080CA57 /* AllReviewView.swift in Sources */,
 				549B1FD52C0618D7005C9432 /* FontExtension.swift in Sources */,
 				544BB7692C1699C800BD43E0 /* UIImageExtension.swift in Sources */,
 				544BB7672C168F8400BD43E0 /* MainTabView.swift in Sources */,
@@ -661,6 +676,7 @@
 				549B1F8F2C0607C7005C9432 /* CheffiApp.swift in Sources */,
 				540BE9B42C231036009180AE /* WriterRow.swift in Sources */,
 				54073B882C0D913800597973 /* NavigationBarFeature.swift in Sources */,
+				5419304B2C3D497D0080CA57 /* AllReviewFeature.swift in Sources */,
 				543F0AE42C10263100DFBDB1 /* HomeCheffiStoryView.swift in Sources */,
 				A6F5E7002C284E400053C2E8 /* KeychainManager.swift in Sources */,
 				A611D9D52C187D8400ABF38C /* NetworkClient.swift in Sources */,

--- a/Cheffi.xcodeproj/project.pbxproj
+++ b/Cheffi.xcodeproj/project.pbxproj
@@ -19,6 +19,13 @@
 		540BE9B42C231036009180AE /* WriterRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 540BE9B32C231036009180AE /* WriterRow.swift */; };
 		541930492C3D49640080CA57 /* AllReviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 541930482C3D49640080CA57 /* AllReviewView.swift */; };
 		5419304B2C3D497D0080CA57 /* AllReviewFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5419304A2C3D497D0080CA57 /* AllReviewFeature.swift */; };
+		5419304D2C3D798A0080CA57 /* ReviewDetailModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5419304C2C3D798A0080CA57 /* ReviewDetailModel.swift */; };
+		5419304F2C3D7B030080CA57 /* Restaurant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5419304E2C3D7B030080CA57 /* Restaurant.swift */; };
+		541930512C3D7B160080CA57 /* Address.swift in Sources */ = {isa = PBXBuildFile; fileRef = 541930502C3D7B160080CA57 /* Address.swift */; };
+		541930532C3D7B200080CA57 /* Writer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 541930522C3D7B200080CA57 /* Writer.swift */; };
+		541930552C3D7B2E0080CA57 /* Ratings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 541930542C3D7B2E0080CA57 /* Ratings.swift */; };
+		541930572C3D7B410080CA57 /* Menu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 541930562C3D7B410080CA57 /* Menu.swift */; };
+		541930592C3D8BEC0080CA57 /* StringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 541930582C3D8BEC0080CA57 /* StringExtension.swift */; };
 		543F0AE42C10263100DFBDB1 /* HomeCheffiStoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 543F0AE32C10263100DFBDB1 /* HomeCheffiStoryView.swift */; };
 		543F0AE62C10264800DFBDB1 /* HomeCheffiStoryFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 543F0AE52C10264800DFBDB1 /* HomeCheffiStoryFeature.swift */; };
 		544BB7672C168F8400BD43E0 /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 544BB7662C168F8400BD43E0 /* MainTabView.swift */; };
@@ -100,6 +107,13 @@
 		540BE9B32C231036009180AE /* WriterRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriterRow.swift; sourceTree = "<group>"; };
 		541930482C3D49640080CA57 /* AllReviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllReviewView.swift; sourceTree = "<group>"; };
 		5419304A2C3D497D0080CA57 /* AllReviewFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllReviewFeature.swift; sourceTree = "<group>"; };
+		5419304C2C3D798A0080CA57 /* ReviewDetailModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDetailModel.swift; sourceTree = "<group>"; };
+		5419304E2C3D7B030080CA57 /* Restaurant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Restaurant.swift; sourceTree = "<group>"; };
+		541930502C3D7B160080CA57 /* Address.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Address.swift; sourceTree = "<group>"; };
+		541930522C3D7B200080CA57 /* Writer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Writer.swift; sourceTree = "<group>"; };
+		541930542C3D7B2E0080CA57 /* Ratings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Ratings.swift; sourceTree = "<group>"; };
+		541930562C3D7B410080CA57 /* Menu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Menu.swift; sourceTree = "<group>"; };
+		541930582C3D8BEC0080CA57 /* StringExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtension.swift; sourceTree = "<group>"; };
 		543F0AE32C10263100DFBDB1 /* HomeCheffiStoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCheffiStoryView.swift; sourceTree = "<group>"; };
 		543F0AE52C10264800DFBDB1 /* HomeCheffiStoryFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCheffiStoryFeature.swift; sourceTree = "<group>"; };
 		544BB7662C168F8400BD43E0 /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
@@ -412,6 +426,7 @@
 				54073B6B2C0C474200597973 /* ImageExtension.swift */,
 				544BB7682C1699C800BD43E0 /* UIImageExtension.swift */,
 				A6F5E6CD2C1B2BA80053C2E8 /* DataExtension.swift */,
+				541930582C3D8BEC0080CA57 /* StringExtension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -457,6 +472,7 @@
 				A688B0AC2C29B68E00E4E3A2 /* LoginKakaoModel.swift */,
 				54F217AA2C2D2F1B00892DBD /* ReviewModel.swift */,
 				54E285F92C2FE28700AD7939 /* TagsModel.swift */,
+				5419304C2C3D798A0080CA57 /* ReviewDetailModel.swift */,
 				A688B0AE2C29B69600E4E3A2 /* Objects */,
 			);
 			path = Models;
@@ -467,6 +483,11 @@
 			children = (
 				A688B0AF2C29B6A800E4E3A2 /* Authority.swift */,
 				54F217AC2C2D2FDB00892DBD /* Photo.swift */,
+				5419304E2C3D7B030080CA57 /* Restaurant.swift */,
+				541930502C3D7B160080CA57 /* Address.swift */,
+				541930522C3D7B200080CA57 /* Writer.swift */,
+				541930542C3D7B2E0080CA57 /* Ratings.swift */,
+				541930562C3D7B410080CA57 /* Menu.swift */,
 			);
 			path = Objects;
 			sourceTree = "<group>";
@@ -659,6 +680,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				54F217AD2C2D2FDB00892DBD /* Photo.swift in Sources */,
+				5419304F2C3D7B030080CA57 /* Restaurant.swift in Sources */,
 				A6F5E6ED2C246A750053C2E8 /* KakaoLoginHandler.swift in Sources */,
 				54073B7D2C0C564700597973 /* HomeView.swift in Sources */,
 				548FC68C2C2177E8003866A9 /* ReviewDetailView.swift in Sources */,
@@ -681,17 +703,23 @@
 				A6F5E7002C284E400053C2E8 /* KeychainManager.swift in Sources */,
 				A611D9D52C187D8400ABF38C /* NetworkClient.swift in Sources */,
 				A6F5E6CC2C1B22C00053C2E8 /* NetworkEventLogger.swift in Sources */,
+				541930592C3D8BEC0080CA57 /* StringExtension.swift in Sources */,
 				A611D9D12C187D6500ABF38C /* EndPoint.swift in Sources */,
 				54F217A92C2BC42A00892DBD /* ScrollViewOffset.swift in Sources */,
 				54073B8C2C0D98E500597973 /* PlaceCell.swift in Sources */,
+				5419304D2C3D798A0080CA57 /* ReviewDetailModel.swift in Sources */,
 				543F0AE62C10264800DFBDB1 /* HomeCheffiStoryFeature.swift in Sources */,
+				541930532C3D7B200080CA57 /* Writer.swift in Sources */,
 				54E285FA2C2FE28700AD7939 /* TagsModel.swift in Sources */,
+				541930512C3D7B160080CA57 /* Address.swift in Sources */,
 				A611D9D32C187D7800ABF38C /* RestRouter.swift in Sources */,
 				A6F5E6F92C280AC00053C2E8 /* RestRouter+EndPoint.swift in Sources */,
 				A688B0B02C29B6A800E4E3A2 /* Authority.swift in Sources */,
 				549B1FDB2C061CE3005C9432 /* ColorExtension.swift in Sources */,
 				A688B0AB2C29B68600E4E3A2 /* RestResponse.swift in Sources */,
 				54F217AB2C2D2F1B00892DBD /* ReviewModel.swift in Sources */,
+				541930572C3D7B410080CA57 /* Menu.swift in Sources */,
+				541930552C3D7B2E0080CA57 /* Ratings.swift in Sources */,
 				A6F5E6E82C245EBD0053C2E8 /* KakaoAuthClient.swift in Sources */,
 				54073B6C2C0C474200597973 /* ImageExtension.swift in Sources */,
 				A6F5E6C82C1B21630053C2E8 /* NetworkRequestInterceptor.swift in Sources */,

--- a/Cheffi.xcodeproj/project.pbxproj
+++ b/Cheffi.xcodeproj/project.pbxproj
@@ -35,6 +35,8 @@
 		54588AD92C074CF9000DD5A9 /* SUIT-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 54588AD42C074CF9000DD5A9 /* SUIT-Regular.otf */; };
 		54588ADA2C074CF9000DD5A9 /* SUIT-ExtraBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 54588AD52C074CF9000DD5A9 /* SUIT-ExtraBold.otf */; };
 		54588ADB2C074CF9000DD5A9 /* SUIT-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 54588AD62C074CF9000DD5A9 /* SUIT-SemiBold.otf */; };
+		5488EDD22C3E534700252A92 /* ViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5488EDD12C3E534700252A92 /* ViewExtension.swift */; };
+		5488EDD42C3E66D700252A92 /* ToastMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5488EDD32C3E66D700252A92 /* ToastMessage.swift */; };
 		548FC68C2C2177E8003866A9 /* ReviewDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 548FC68B2C2177E8003866A9 /* ReviewDetailView.swift */; };
 		549B1F8F2C0607C7005C9432 /* CheffiApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 549B1F8E2C0607C7005C9432 /* CheffiApp.swift */; };
 		549B1F912C0607C7005C9432 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 549B1F902C0607C7005C9432 /* ContentView.swift */; };
@@ -123,6 +125,8 @@
 		54588AD42C074CF9000DD5A9 /* SUIT-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SUIT-Regular.otf"; sourceTree = "<group>"; };
 		54588AD52C074CF9000DD5A9 /* SUIT-ExtraBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SUIT-ExtraBold.otf"; sourceTree = "<group>"; };
 		54588AD62C074CF9000DD5A9 /* SUIT-SemiBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SUIT-SemiBold.otf"; sourceTree = "<group>"; };
+		5488EDD12C3E534700252A92 /* ViewExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewExtension.swift; sourceTree = "<group>"; };
+		5488EDD32C3E66D700252A92 /* ToastMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastMessage.swift; sourceTree = "<group>"; };
 		548FC68B2C2177E8003866A9 /* ReviewDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDetailView.swift; sourceTree = "<group>"; };
 		549B1F8B2C0607C7005C9432 /* Cheffi.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Cheffi.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		549B1F8E2C0607C7005C9432 /* CheffiApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheffiApp.swift; sourceTree = "<group>"; };
@@ -310,6 +314,7 @@
 			children = (
 				54F217A82C2BC42A00892DBD /* ScrollViewOffset.swift */,
 				A6F5E6FF2C284E400053C2E8 /* KeychainManager.swift */,
+				5488EDD32C3E66D700252A92 /* ToastMessage.swift */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -427,6 +432,7 @@
 				544BB7682C1699C800BD43E0 /* UIImageExtension.swift */,
 				A6F5E6CD2C1B2BA80053C2E8 /* DataExtension.swift */,
 				541930582C3D8BEC0080CA57 /* StringExtension.swift */,
+				5488EDD12C3E534700252A92 /* ViewExtension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -686,6 +692,7 @@
 				548FC68C2C2177E8003866A9 /* ReviewDetailView.swift in Sources */,
 				541930492C3D49640080CA57 /* AllReviewView.swift in Sources */,
 				549B1FD52C0618D7005C9432 /* FontExtension.swift in Sources */,
+				5488EDD42C3E66D700252A92 /* ToastMessage.swift in Sources */,
 				544BB7692C1699C800BD43E0 /* UIImageExtension.swift in Sources */,
 				544BB7672C168F8400BD43E0 /* MainTabView.swift in Sources */,
 				549B1F912C0607C7005C9432 /* ContentView.swift in Sources */,
@@ -721,6 +728,7 @@
 				541930572C3D7B410080CA57 /* Menu.swift in Sources */,
 				541930552C3D7B2E0080CA57 /* Ratings.swift in Sources */,
 				A6F5E6E82C245EBD0053C2E8 /* KakaoAuthClient.swift in Sources */,
+				5488EDD22C3E534700252A92 /* ViewExtension.swift in Sources */,
 				54073B6C2C0C474200597973 /* ImageExtension.swift in Sources */,
 				A6F5E6C82C1B21630053C2E8 /* NetworkRequestInterceptor.swift in Sources */,
 				A6F5E6EB2C246A670053C2E8 /* KakaoTokenVerifier.swift in Sources */,

--- a/Cheffi/Application/Resource/Assets.xcassets/check.imageset/Contents.json
+++ b/Cheffi/Application/Resource/Assets.xcassets/check.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "check.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cheffi/Application/Resource/Assets.xcassets/check.imageset/check.svg
+++ b/Cheffi/Application/Resource/Assets.xcassets/check.imageset/check.svg
@@ -1,0 +1,4 @@
+<svg width="19" height="18" viewBox="0 0 19 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="9.5" cy="9" r="8" fill="white" stroke="white" stroke-width="2"/>
+<path d="M5 9.6L7.57143 12L14 6" stroke="#7E7E7E" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/Cheffi/Module/Component/Extensions/ImageExtension.swift
+++ b/Cheffi/Module/Component/Extensions/ImageExtension.swift
@@ -19,6 +19,7 @@ enum Common: String, ImageNameProtocol {
     case clock = "clock"
     case info = "info"
     case lock = "lock"
+    case check = "check"
 }
 
 enum Tab: String, ImageNameProtocol {

--- a/Cheffi/Module/Component/Extensions/StringExtension.swift
+++ b/Cheffi/Module/Component/Extensions/StringExtension.swift
@@ -1,0 +1,35 @@
+//
+//  StringExtension.swift
+//  Cheffi
+//
+//  Created by 정건호 on 7/10/24.
+//
+
+import Foundation
+
+extension String {
+    func timeAgo() -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+        dateFormatter.locale = Locale(identifier: "ko-KR")
+        
+        guard let date = dateFormatter.date(from: self) else { return String() }
+        
+        let now = Date()
+        let calendar = Calendar.current
+        
+        let components = calendar.dateComponents([.minute, .hour, .day, .month], from: date, to: now)
+        
+        if let months = components.month, months >= 1 {
+            return "\(months)달 전"
+        } else if let days = components.day, days >= 1 {
+            return "\(days)일 전"
+        } else if let hours = components.hour, hours < 24 {
+            return "\(hours)시간 전"
+        } else if let minutes = components.minute, minutes < 60 {
+            return "방금 전"
+        }
+        
+        return String()
+    }
+}

--- a/Cheffi/Module/Component/Extensions/ViewExtension.swift
+++ b/Cheffi/Module/Component/Extensions/ViewExtension.swift
@@ -1,0 +1,26 @@
+//
+//  ViewExtension.swift
+//  Cheffi
+//
+//  Created by 정건호 on 7/10/24.
+//
+
+import SwiftUI
+
+extension View {
+    func toast(
+        message: String,
+        type: ToastType,
+        isShowing: Binding<Bool>,
+        onCancel: (() -> Void)? = nil
+    ) -> some View {
+        self.modifier(
+            ToastMessage(
+                message: message,
+                type: type,
+                isShowing: isShowing,
+                onCancel: onCancel
+            )
+        )
+    }
+}

--- a/Cheffi/Module/Component/Models/Objects/Address.swift
+++ b/Cheffi/Module/Component/Models/Objects/Address.swift
@@ -1,0 +1,24 @@
+//
+//  Address.swift
+//  Cheffi
+//
+//  Created by 정건호 on 7/9/24.
+//
+
+import Foundation
+
+struct Address: Codable, Equatable {
+    let province: String
+    let city: String
+    let roadName: String
+    let fullLotNumberAddress: String
+    let fullRoadNameAddress: String
+    
+    enum CodingKeys: String, CodingKey {
+        case province
+        case city
+        case roadName = "road_name"
+        case fullLotNumberAddress = "full_lot_number_address"
+        case fullRoadNameAddress = "full_rod_name_address"
+    }
+}

--- a/Cheffi/Module/Component/Models/Objects/Menu.swift
+++ b/Cheffi/Module/Component/Models/Objects/Menu.swift
@@ -1,0 +1,14 @@
+//
+//  Menu.swift
+//  Cheffi
+//
+//  Created by 정건호 on 7/9/24.
+//
+
+import Foundation
+
+struct Menu: Codable, Equatable {
+    let name: String
+    let price: Int
+    let description: String
+}

--- a/Cheffi/Module/Component/Models/Objects/Ratings.swift
+++ b/Cheffi/Module/Component/Models/Objects/Ratings.swift
@@ -1,0 +1,20 @@
+//
+//  Ratings.swift
+//  Cheffi
+//
+//  Created by 정건호 on 7/9/24.
+//
+
+import Foundation
+
+struct Ratings: Codable, Equatable {
+    let good: Int
+    let average: Int
+    let bad: Int
+    
+    enum CodingKeys: String, CodingKey {
+        case good = "GOOD"
+        case average = "AVERAGE"
+        case bad = "BAD"
+    }
+}

--- a/Cheffi/Module/Component/Models/Objects/Restaurant.swift
+++ b/Cheffi/Module/Component/Models/Objects/Restaurant.swift
@@ -1,0 +1,15 @@
+//
+//  Restaurant.swift
+//  Cheffi
+//
+//  Created by 정건호 on 7/9/24.
+//
+
+import Foundation
+
+struct Restaurant: Codable, Equatable {
+    let id: Int
+    let name: String
+    let address: Address
+    let registered: Bool
+}

--- a/Cheffi/Module/Component/Models/Objects/Writer.swift
+++ b/Cheffi/Module/Component/Models/Objects/Writer.swift
@@ -1,0 +1,24 @@
+//
+//  Writer.swift
+//  Cheffi
+//
+//  Created by 정건호 on 7/9/24.
+//
+
+import Foundation
+
+struct Writer: Codable, Equatable {
+    let id: Int
+    let nickname: String
+    let photoURL: String
+    let introduction: String
+    let writtenByViewer: Bool
+    
+    enum CodingKeys: String, CodingKey {
+        case id
+        case nickname
+        case photoURL = "photo_url"
+        case introduction
+        case writtenByViewer = "written_by_viewer"
+    }
+}

--- a/Cheffi/Module/Component/Models/ReviewDetailModel.swift
+++ b/Cheffi/Module/Component/Models/ReviewDetailModel.swift
@@ -1,0 +1,52 @@
+//
+//  ReviewDetailModel.swift
+//  Cheffi
+//
+//  Created by 정건호 on 7/9/24.
+//
+
+import Foundation
+
+typealias ReviewDetailResponse = RestResponse<ReviewDetailModel>
+
+struct ReviewDetailModel: Codable, Equatable {
+    let id: Int
+    let title: String
+    let text: String
+    let bookmarked: Bool
+    let ratedByUser: Bool
+    let ratingType: String?
+    let createdDate: String
+    let timeLeftToLock: Int64
+    let matchedTagNum: Int?
+    let restaurant: Restaurant
+    let writer: Writer
+    let ratings: Ratings
+    let photos: [Photo]
+    let menus: [Menu]
+    
+    enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case text
+        case bookmarked
+        case ratedByUser = "rated_by_user"
+        case ratingType = "rating_type"
+        case createdDate = "created_date"
+        case timeLeftToLock = "time_left_to_lock"
+        case matchedTagNum = "matched_tag_num"
+        case restaurant
+        case writer
+        case ratings
+        case photos
+        case menus
+    }
+}
+
+
+
+
+
+
+
+

--- a/Cheffi/Module/Component/Util/ToastMessage.swift
+++ b/Cheffi/Module/Component/Util/ToastMessage.swift
@@ -1,0 +1,101 @@
+//
+//  ToastMessage.swift
+//  Cheffi
+//
+//  Created by 정건호 on 7/10/24.
+//
+
+import SwiftUI
+
+enum ToastType {
+    case normal
+    case check
+    case cancellable
+}
+
+struct ToastMessage: ViewModifier {
+    let message: String
+    let type: ToastType
+    @Binding var isShowing: Bool
+    var onCancel: (() -> Void)?
+    
+    @State private var dismissWorkItem: DispatchWorkItem?
+    
+    func body(content: Content) -> some View {
+        ZStack {
+            content
+            toastView
+        }
+    }
+    
+    private var toastView: some View {
+        VStack {
+            Spacer()
+            Group {
+                if isShowing {
+                    if type == .normal {
+                        Text(message)
+                            .multilineTextAlignment(.center)
+                            .foregroundStyle(Color.white)
+                            .font(.suit(.medium, 16))
+                            .onAppear {
+                                dismissWork()
+                            }
+                    } else if type == .check {
+                        HStack(spacing: 8) {
+                            Image(name: Common.check)
+                            Text(message)
+                                .multilineTextAlignment(.center)
+                                .foregroundStyle(Color.white)
+                                .font(.suit(.medium, 16))
+                                .onAppear {
+                                    dismissWork()
+                                }
+                        }
+                    } else if type == .cancellable {
+                        HStack(spacing: 22) {
+                            Text(message)
+                                .multilineTextAlignment(.center)
+                                .foregroundStyle(Color.white)
+                                .font(.suit(.medium, 16))
+                                .onAppear {
+                                    dismissWork()
+                                }
+                            Text("취소")
+                                .foregroundStyle(Color.grey7)
+                                .font(.suit(.medium, 16))
+                                .padding(EdgeInsets(top: 5, leading: 17, bottom: 5, trailing: 17))
+                                .background(Color.grey05)
+                                .clipShape(.rect(cornerRadius: 10))
+                                .onTapGesture {
+                                    isShowing = false
+                                    dismissWorkItem?.cancel()
+                                    onCancel?()
+                                }
+                        }
+                    }
+                }
+            }
+            .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: 54)
+            .padding(.horizontal, 12)
+            .background(Color.alarm_bg.opacity(0.9))
+            .cornerRadius(8)
+        }
+        .padding(.horizontal, 16)
+        .padding(.bottom, 35)
+        .animation(.linear(duration: 0.3), value: isShowing)
+        .transition(.opacity)
+    }
+    
+    private func dismissWork() {
+        dismissWorkItem?.cancel()
+        
+        let workItem = DispatchWorkItem {
+            isShowing = false
+        }
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3, execute: workItem)
+        
+        dismissWorkItem = workItem
+    }
+}

--- a/Cheffi/Module/Component/View/WriterRow.swift
+++ b/Cheffi/Module/Component/View/WriterRow.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Kingfisher
 
 struct WriterRow: View {
     let imageUrl: String
@@ -15,10 +16,17 @@ struct WriterRow: View {
     
     var body: some View {
         HStack {
-            Image(name: Dummy.sample)
-                .resizable()
-                .frame(width: 64, height: 64)
-                .clipShape(.rect(cornerRadius: 8))
+            Group {
+                if let url = URL(string: imageUrl) {
+                    KFImage(url)
+                        .resizable()
+                } else {
+                    // TODO: 이미지 불러오지 못했을 때 UI 요청
+                    Color.grey3
+                }
+            }
+            .frame(width: 64, height: 64)
+            .clipShape(.rect(cornerRadius: 8))
             Spacer().frame(width: 12)
             VStack(alignment: .leading, spacing: 6) {
                 Text(title)

--- a/Cheffi/Module/Feature/AllReviewView/AllReviewFeature.swift
+++ b/Cheffi/Module/Feature/AllReviewView/AllReviewFeature.swift
@@ -1,17 +1,17 @@
 //
-//  ReviewDetailFeature.swift
+//  AllReviewFeature.swift
 //  Cheffi
 //
-//  Created by 정건호 on 6/19/24.
+//  Created by 정건호 on 7/9/24.
 //
 
 import Foundation
 import ComposableArchitecture
 
-struct ReviewDetailFeature: Reducer {
+struct AllReviewFeature: Reducer {
     
     struct State: Equatable {
-        var id: Int
+        
     }
     
     enum Action: Equatable {

--- a/Cheffi/Module/Feature/AllReviewView/AllReviewView.swift
+++ b/Cheffi/Module/Feature/AllReviewView/AllReviewView.swift
@@ -1,0 +1,24 @@
+//
+//  AllReviewView.swift
+//  Cheffi
+//
+//  Created by 정건호 on 7/9/24.
+//
+
+import SwiftUI
+import ComposableArchitecture
+
+struct AllReviewView: View {
+    private let store: StoreOf<AllReviewFeature> = .init(
+        initialState: AllReviewFeature.State()) {
+            AllReviewFeature()
+        }
+    
+    var body: some View {
+        Text("전체 리뷰")
+    }
+}
+
+#Preview {
+    AllReviewView()
+}

--- a/Cheffi/Module/Feature/Home/CheffiPlace/HomeCheffiPlaceFeature.swift
+++ b/Cheffi/Module/Feature/Home/CheffiPlace/HomeCheffiPlaceFeature.swift
@@ -8,10 +8,13 @@
 import Foundation
 import Combine
 import ComposableArchitecture
+import Perception
 
-struct HomeCheffiPlaceFeature: Reducer {
+@Reducer
+struct HomeCheffiPlaceFeature {
     @Dependency(\.networkClient) var networkClient
     
+    @ObservableState
     struct State: Equatable {
         var tags: [TagsModel] = []
         var cursors: [Int: Int] = [:]

--- a/Cheffi/Module/Feature/Home/CheffiPlace/HomeCheffiPlaceFeature.swift
+++ b/Cheffi/Module/Feature/Home/CheffiPlace/HomeCheffiPlaceFeature.swift
@@ -34,7 +34,7 @@ struct HomeCheffiPlaceFeature {
         Reduce { state, action in
             switch action {
             case .requestTags:
-                return .publisher {
+                return Effect.publisher {
                     return networkClient
                         .request(.tags(type: "FOOD"))
                         .map { Action.tagsResponse(.success($0)) }
@@ -58,7 +58,7 @@ struct HomeCheffiPlaceFeature {
                 return .none
                 
             case .requestCheffiPlace(let cursor, let tagId):
-                return .publisher {
+                return Effect.publisher {
                     return networkClient
                         .request(.cheffiPlace(province: "서울특별시", city: "강남구", cursor: cursor, size: 16, tag_id: tagId))
                         .map { Action.cheffiPlaceResponse(tagId: tagId, .success($0)) }

--- a/Cheffi/Module/Feature/Home/CheffiPlace/HomeCheffiPlaceView.swift
+++ b/Cheffi/Module/Feature/Home/CheffiPlace/HomeCheffiPlaceView.swift
@@ -10,13 +10,13 @@ import ComposableArchitecture
 
 struct HomeCheffiPlaceView: View {
     
-    private let store: StoreOf<HomeCheffiPlaceFeature> = .init(
+    @Perception.Bindable var store: StoreOf<HomeCheffiPlaceFeature> = .init(
         initialState: HomeCheffiPlaceFeature.State()) {
             HomeCheffiPlaceFeature()
         }
     
     @State private var selectedTab: Int = 0
-    @State private var tabViewHeight: CGFloat = UIWindow().screen.bounds.height - 284
+    let tabViewHeight: CGFloat = UIWindow().screen.bounds.height - 284
     
     private let columns = [
         GridItem(.flexible(), alignment: .top),
@@ -24,39 +24,41 @@ struct HomeCheffiPlaceView: View {
     ]
     
     var body: some View {
-        WithViewStore(self.store, observe: { $0 }) { viewStore in
+        WithPerceptionTracking {
             LazyVStack(alignment: .leading, spacing: 0, pinnedViews: [.sectionHeaders]) {
                 Section(content: {
                     VStack(spacing: 0) {
                         TabView(selection: $selectedTab) {
-                            ForEach(0..<viewStore.state.tags.count, id: \.self) { index in
-                                let tagId = viewStore.state.tags[index].id
-                                if let reviews = viewStore.state.cheffiPlaceReviews[tagId], !reviews.isEmpty {
-                                    ScrollView(showsIndicators: false) {
-                                        LazyVGrid(columns: columns, spacing: 24) {
-                                            ForEach(reviews, id: \.id) { review in
-                                                PlaceCell(review: review, type: .small)
+                            ForEach(0..<store.state.tags.count, id: \.self) { index in
+                                WithPerceptionTracking {
+                                    let tagId = store.state.tags[index].id
+                                    if let reviews = store.state.cheffiPlaceReviews[tagId], !reviews.isEmpty {
+                                        ScrollView(showsIndicators: false) {
+                                            LazyVGrid(columns: columns, spacing: 24) {
+                                                ForEach(reviews, id: \.id) { review in
+                                                    PlaceCell(review: review, type: .small)
+                                                }
                                             }
+                                            .padding(.horizontal, 16)
+                                            .tag(index)
                                         }
-                                        .padding(.horizontal, 16)
-                                        .tag(index)
-                                    }
-                                } else {
-                                    VStack(alignment: .center, spacing: 0) {
-                                        Image(name: Home.homeEmpty)
-                                            .padding(.bottom, 12)
-                                        Text("아직 주변의 \(viewStore.state.tags[index].name) 맛집 리뷰가 없어요\n먼저 주변 아는 맛집을 소개해주세요!")
-                                            .font(.suit(.medium, 14))
-                                            .foregroundStyle(Color.grey6)
-                                            .padding(.bottom, 18)
-                                            .multilineTextAlignment(.center)
-                                        Text("맛집 직접 등록하기")
-                                            .font(.suit(.semiBold, 15))
-                                            .foregroundStyle(Color.primary)
-                                            .padding(.horizontal, 14)
-                                            .padding(.vertical, 9)
-                                            .background(Color.background)
-                                            .clipShape(.rect(cornerRadius: 10))
+                                    } else {
+                                        VStack(alignment: .center, spacing: 0) {
+                                            Image(name: Home.homeEmpty)
+                                                .padding(.bottom, 12)
+                                            Text("아직 주변의 \(store.state.tags[index].name) 맛집 리뷰가 없어요\n먼저 주변 아는 맛집을 소개해주세요!")
+                                                .font(.suit(.medium, 14))
+                                                .foregroundStyle(Color.grey6)
+                                                .padding(.bottom, 18)
+                                                .multilineTextAlignment(.center)
+                                            Text("맛집 직접 등록하기")
+                                                .font(.suit(.semiBold, 15))
+                                                .foregroundStyle(Color.primary)
+                                                .padding(.horizontal, 14)
+                                                .padding(.vertical, 9)
+                                                .background(Color.background)
+                                                .clipShape(.rect(cornerRadius: 10))
+                                        }
                                     }
                                 }
                             }
@@ -77,27 +79,29 @@ struct HomeCheffiPlaceView: View {
                         ScrollViewReader { proxy in
                             ScrollView(.horizontal, showsIndicators: false) {
                                 HStack(spacing: 0) {
-                                    ForEach(0..<viewStore.state.tags.count, id: \.self) { index in
-                                        VStack {
-                                            Text(viewStore.state.tags[index].name)
-                                                .foregroundColor(selectedTab == index ? Color.primary : Color.grey5)
-                                                .font(.suit(.bold, 15))
-                                                .frame(maxWidth: .infinity)
-                                                .padding(EdgeInsets(top: 10, leading: 16, bottom: 8, trailing: 16))
-                                                .onTapGesture {
-                                                    selectedTab = index
-                                                }
-                                            Rectangle()
-                                                .frame(height: 2)
-                                                .foregroundColor(selectedTab == index ? .red : .clear)
-                                                .layoutPriority(1)
-                                        }
-                                        .id(index)
-                                        .onChange(of: selectedTab) { index in
-                                            withAnimation {
-                                                proxy.scrollTo(index, anchor: .center)
+                                    ForEach(0..<store.state.tags.count, id: \.self) { index in
+                                        WithPerceptionTracking {
+                                            VStack {
+                                                Text(store.state.tags[index].name)
+                                                    .foregroundColor(selectedTab == index ? Color.primary : Color.grey5)
+                                                    .font(.suit(.bold, 15))
+                                                    .frame(maxWidth: .infinity)
+                                                    .padding(EdgeInsets(top: 10, leading: 16, bottom: 8, trailing: 16))
+                                                    .onTapGesture {
+                                                        selectedTab = index
+                                                    }
+                                                Rectangle()
+                                                    .frame(height: 2)
+                                                    .foregroundColor(selectedTab == index ? .red : .clear)
+                                                    .layoutPriority(1)
                                             }
-                                            viewStore.send(.requestCheffiPlace(tagId: (viewStore.state.tags[index].id)))
+                                            .id(index)
+                                            .onChange(of: selectedTab) { index in
+                                                withAnimation {
+                                                    proxy.scrollTo(index, anchor: .center)
+                                                }
+                                                store.send(.requestCheffiPlace(tagId: (store.state.tags[index].id)))
+                                            }
                                         }
                                     }
                                 }
@@ -113,8 +117,8 @@ struct HomeCheffiPlaceView: View {
                 })
             }
             .onAppear {
-                viewStore.send(.requestTags)
-                viewStore.send(.requestCheffiPlace(tagId: 1))
+                store.send(.requestTags)
+                store.send(.requestCheffiPlace(tagId: 1))
             }
         }
     }

--- a/Cheffi/Module/Feature/Home/CheffiStory/HomeCheffiStoryFeature.swift
+++ b/Cheffi/Module/Feature/Home/CheffiStory/HomeCheffiStoryFeature.swift
@@ -8,8 +8,10 @@
 import Foundation
 import ComposableArchitecture
 
-struct HomeCheffiStoryFeature: Reducer {
+@Reducer
+struct HomeCheffiStoryFeature {
     
+    @ObservableState
     struct State: Equatable {
         var selectedCategories: [String] = []
         var recommendList: [RecommendData] = []

--- a/Cheffi/Module/Feature/Home/CheffiStory/HomeCheffiStoryView.swift
+++ b/Cheffi/Module/Feature/Home/CheffiStory/HomeCheffiStoryView.swift
@@ -10,7 +10,7 @@ import ComposableArchitecture
 
 struct HomeCheffiStoryView: View {
     
-    private let store: StoreOf<HomeCheffiStoryFeature> = .init(
+    @Perception.Bindable var store: StoreOf<HomeCheffiStoryFeature> = .init(
         initialState: HomeCheffiStoryFeature.State()) {
             HomeCheffiStoryFeature()
         }
@@ -39,7 +39,7 @@ struct HomeCheffiStoryView: View {
     }
     
     var body: some View {
-        WithViewStore(self.store, observe: { $0 }) { viewStore in
+        WithPerceptionTracking {
             VStack {
                 HStack {
                     Text("음식, 분위기 맛\n나와 비슷한 쉐피들의 이야기")
@@ -53,30 +53,32 @@ struct HomeCheffiStoryView: View {
                 ScrollView(.horizontal, showsIndicators: false) {
                     HStack(spacing: 8) {
                         ForEach($dummyCategories, id: \.self) { category in
-                            Group {
-                                if !viewStore.state.selectedCategories.contains(category.wrappedValue) {
-                                    Text("\(category.wrappedValue)")
-                                        .foregroundStyle(Color.grey5)
-                                        .font(.suit(.semiBold, 15))
-                                        .padding(.horizontal, 16)
-                                        .padding(.vertical, 6)
-                                        .background(
-                                            RoundedRectangle(cornerRadius: 20)
-                                                .strokeBorder(Color.grey1)
-                                        )
-                                    
-                                } else {
-                                    Text("\(category.wrappedValue)")
-                                        .foregroundStyle(Color.white)
-                                        .font(.suit(.semiBold, 15))
-                                        .padding(.horizontal, 16)
-                                        .padding(.vertical, 6)
-                                        .background(Color.primary)
-                                        .clipShape(.rect(cornerRadius: 20))
+                            WithPerceptionTracking {
+                                Group {
+                                    if !store.state.selectedCategories.contains(category.wrappedValue) {
+                                        Text("\(category.wrappedValue)")
+                                            .foregroundStyle(Color.grey5)
+                                            .font(.suit(.semiBold, 15))
+                                            .padding(.horizontal, 16)
+                                            .padding(.vertical, 6)
+                                            .background(
+                                                RoundedRectangle(cornerRadius: 20)
+                                                    .strokeBorder(Color.grey1)
+                                            )
+                                        
+                                    } else {
+                                        Text("\(category.wrappedValue)")
+                                            .foregroundStyle(Color.white)
+                                            .font(.suit(.semiBold, 15))
+                                            .padding(.horizontal, 16)
+                                            .padding(.vertical, 6)
+                                            .background(Color.primary)
+                                            .clipShape(.rect(cornerRadius: 20))
+                                    }
                                 }
-                            }
-                            .onTapGesture {
-                                viewStore.send(.categoryTapped(category.wrappedValue))
+                                .onTapGesture {
+                                    store.send(.categoryTapped(category.wrappedValue))
+                                }
                             }
                         }
                     }
@@ -86,21 +88,25 @@ struct HomeCheffiStoryView: View {
                 
                 TabView(selection: $currentpage) {
                     ForEach(1...totalPage, id: \.self) { index in
-                        VStack(spacing: 16) {
-                            let startIndex = (index - 1) * itemsPerPage
-                            let endIndex = min(startIndex + itemsPerPage, dummyDatas.count)
-                            let items = Array(dummyDatas[startIndex..<endIndex])
-                            ForEach(items, id: \.title) { item in
-                                WriterRow(
-                                    imageUrl: String(),
-                                    title: item.title,
-                                    intro: item.intro,
-                                    isFollowed: item.isFollowed
-                                )
-                            }
-                            .padding(.horizontal, 16)
-                            if items.count != 3 {
-                                Spacer()
+                        WithPerceptionTracking {
+                            VStack(spacing: 16) {
+                                let startIndex = (index - 1) * itemsPerPage
+                                let endIndex = min(startIndex + itemsPerPage, dummyDatas.count)
+                                let items = Array(dummyDatas[startIndex..<endIndex])
+                                ForEach(items, id: \.title) { item in
+                                    WithPerceptionTracking {
+                                        WriterRow(
+                                            imageUrl: String(),
+                                            title: item.title,
+                                            intro: item.intro,
+                                            isFollowed: item.isFollowed
+                                        )
+                                    }
+                                }
+                                .padding(.horizontal, 16)
+                                if items.count != 3 {
+                                    Spacer()
+                                }
                             }
                         }
                     }
@@ -135,7 +141,7 @@ struct HomeCheffiStoryView: View {
                 }
             }
             .onAppear {
-                viewStore.send(.onAppear)
+                store.send(.onAppear)
             }
         }
     }

--- a/Cheffi/Module/Feature/Home/HomeView.swift
+++ b/Cheffi/Module/Feature/Home/HomeView.swift
@@ -10,7 +10,8 @@ import ComposableArchitecture
 
 struct HomeView: View {
     var body: some View {
-        NavigationView {
+        VStack {
+            NavigationBarView()
             ScrollView(showsIndicators: false) {
                 // 인기 급등 맛집
                 HomePopularView()
@@ -24,20 +25,6 @@ struct HomeView: View {
                 HomeCheffiPlaceView()
                     .padding(.top, 32)
             }
-            .toolbar {
-                ToolbarItem(placement: .principal) {
-                    NavigationBarView()
-                }
-            }
-            .navigationBarTitleDisplayMode(.inline)
-        }
-        .onAppear {
-            // NavigationBar의 shadow 제거
-            let appearace = UINavigationBarAppearance()
-            appearace.shadowColor = .clear
-            appearace.backgroundColor = .white
-            UINavigationBar.appearance().standardAppearance = appearace
-            UINavigationBar.appearance().scrollEdgeAppearance = appearace
         }
     }
 }

--- a/Cheffi/Module/Feature/Home/NavigationBar/NavigationBarFeature.swift
+++ b/Cheffi/Module/Feature/Home/NavigationBar/NavigationBarFeature.swift
@@ -8,8 +8,10 @@
 import Foundation
 import ComposableArchitecture
 
-struct NavigationBarFeature: Reducer {
+@Reducer
+struct NavigationBarFeature {
     
+    @ObservableState
     struct State: Equatable {
         
     }

--- a/Cheffi/Module/Feature/Home/NavigationBar/NavigationBarView.swift
+++ b/Cheffi/Module/Feature/Home/NavigationBar/NavigationBarView.swift
@@ -46,6 +46,7 @@ struct NavigationBarView: View {
                         viewStore.send(.alarmTapped)
                     }
             }
+            .padding(.horizontal, 16)
         }
     }
 }

--- a/Cheffi/Module/Feature/Home/NavigationBar/NavigationBarView.swift
+++ b/Cheffi/Module/Feature/Home/NavigationBar/NavigationBarView.swift
@@ -10,13 +10,13 @@ import ComposableArchitecture
 
 struct NavigationBarView: View {
     
-    let store: StoreOf<NavigationBarFeature> = .init(
+    @Perception.Bindable var store: StoreOf<NavigationBarFeature> = .init(
         initialState: NavigationBarFeature.State()) {
             NavigationBarFeature()
         }
     
     var body: some View {
-        WithViewStore(self.store, observe: { $0 }) { viewStore in
+        WithPerceptionTracking {
             HStack(spacing: 0) {
                 HStack(spacing: 8) {
                     Text("서울특별시 성동구")
@@ -32,18 +32,18 @@ struct NavigationBarView: View {
                         .clipShape(.rect(cornerRadius: 16))
                 }
                 .onTapGesture {
-                    viewStore.send(.regionTapped)
+                    store.send(.regionTapped)
                 }
                 Spacer()
                 Image(name: Home.search)
                     .padding(10)
                     .onTapGesture {
-                        viewStore.send(.searchTapped)
+                        store.send(.searchTapped)
                     }
                 Image(name: Home.alarm)
                     .padding(10)
                     .onTapGesture {
-                        viewStore.send(.alarmTapped)
+                        store.send(.alarmTapped)
                     }
             }
             .padding(.horizontal, 16)

--- a/Cheffi/Module/Feature/Home/Popular/HomePopularFeature.swift
+++ b/Cheffi/Module/Feature/Home/Popular/HomePopularFeature.swift
@@ -36,7 +36,7 @@ struct HomePopularFeature {
         Reduce { state, action in
             switch action {
             case .requestPopularReviews:
-                return .publisher {
+                return Effect.publisher {
                     return networkClient
                         .request(.popularReviews(province: "서울특별시", city: "강남구", cursor: 0, size: 16))
                         .map { Action.popularReviewsResponse(.success($0)) }

--- a/Cheffi/Module/Feature/Home/Popular/HomePopularView.swift
+++ b/Cheffi/Module/Feature/Home/Popular/HomePopularView.swift
@@ -87,47 +87,49 @@ struct HomePopularView: View {
                         
                         TabView(selection: $currentpage) {
                             ForEach(0..<store.totalPage, id: \.self) { index in
-                                VStack {
-                                    if index == 0 {
-                                        NavigationLink(
-                                            state: HomePopularFeature.Path.State.moveToReviewDetailView(.init(id: store.popularReviews[0].id))
-                                        ) {
-                                            PlaceCell(review: store.popularReviews[0], type: .medium)
-                                        }
-                                        LazyVGrid(columns: columns) {
-                                            if store.popularReviews.count-1 >= 1 {
-                                                NavigationLink(
-                                                    state: HomePopularFeature.Path.State.moveToReviewDetailView(.init(id: store.popularReviews[1].id))
-                                                ) {
-                                                    PlaceCell(review: store.popularReviews[1], type: .small)
-                                                }
+                                WithPerceptionTracking {
+                                    VStack {
+                                        if index == 0 {
+                                            NavigationLink(
+                                                state: HomePopularFeature.Path.State.moveToReviewDetailView(.init(id: store.popularReviews[0].id))
+                                            ) {
+                                                PlaceCell(review: store.popularReviews[0], type: .medium)
                                             }
-                                            if store.popularReviews.count-1 >= 2 {
-                                                NavigationLink(
-                                                    state: HomePopularFeature.Path.State.moveToReviewDetailView(.init(id: store.popularReviews[2].id))
-                                                ) {
-                                                    PlaceCell(review: store.popularReviews[2], type: .small)
-                                                }
-                                            }
-                                        }
-                                    } else {
-                                        LazyVGrid(columns: columns) {
-                                            ForEach(0..<4) { offset in
-                                                let reviewIndex = 3 + (index - 1) * 4 + offset
-                                                if store.popularReviews.count-1 >= reviewIndex {
+                                            LazyVGrid(columns: columns) {
+                                                if store.popularReviews.count-1 >= 1 {
                                                     NavigationLink(
-                                                        state: HomePopularFeature.Path.State.moveToReviewDetailView(.init(id: store.popularReviews[reviewIndex].id))
+                                                        state: HomePopularFeature.Path.State.moveToReviewDetailView(.init(id: store.popularReviews[1].id))
                                                     ) {
-                                                        PlaceCell(review: store.popularReviews[reviewIndex], type: .small)
+                                                        PlaceCell(review: store.popularReviews[1], type: .small)
+                                                    }
+                                                }
+                                                if store.popularReviews.count-1 >= 2 {
+                                                    NavigationLink(
+                                                        state: HomePopularFeature.Path.State.moveToReviewDetailView(.init(id: store.popularReviews[2].id))
+                                                    ) {
+                                                        PlaceCell(review: store.popularReviews[2], type: .small)
+                                                    }
+                                                }
+                                            }
+                                        } else {
+                                            LazyVGrid(columns: columns) {
+                                                ForEach(0..<4) { offset in
+                                                    let reviewIndex = 3 + (index - 1) * 4 + offset
+                                                    if store.popularReviews.count-1 >= reviewIndex {
+                                                        NavigationLink(
+                                                            state: HomePopularFeature.Path.State.moveToReviewDetailView(.init(id: store.popularReviews[reviewIndex].id))
+                                                        ) {
+                                                            PlaceCell(review: store.popularReviews[reviewIndex], type: .small)
+                                                        }
                                                     }
                                                 }
                                             }
                                         }
                                     }
+                                    .padding(.horizontal, 16)
+                                    .tag(index + 1)
+                                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
                                 }
-                                .padding(.horizontal, 16)
-                                .tag(index + 1)
-                                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
                             }
                         }
                         .frame(height: store.popularReviews.count == 1 ? 270 : 573, alignment: .center)

--- a/Cheffi/Module/Feature/Home/Popular/HomePopularView.swift
+++ b/Cheffi/Module/Feature/Home/Popular/HomePopularView.swift
@@ -10,7 +10,7 @@ import ComposableArchitecture
 
 struct HomePopularView: View {
     
-    private let store: StoreOf<HomePopularFeature> = .init(
+    @Perception.Bindable var store: StoreOf<HomePopularFeature> = .init(
         initialState: HomePopularFeature.State()) {
             HomePopularFeature()
         }
@@ -23,129 +23,157 @@ struct HomePopularView: View {
     @State private var currentpage = 1
     
     var body: some View {
-        WithViewStore(self.store, observe: { $0 }) { viewStore in
-            VStack(alignment: .leading, spacing: 0) {
-                Text("인기 급등 맛집")
-                    .foregroundStyle(.black)
-                    .font(.suit(.bold, 20))
-                    .padding(.bottom, 16)
-                    .padding(.leading, 16)
-                if viewStore.popularReviews.count == 0 {
-                    VStack(alignment: .center, spacing: 0) {
-                        Image(name: Home.homeEmpty)
-                            .padding(.bottom, 12)
-                        Text("아직 주변의 맛집 리뷰가 없어요\n먼저 주변 아는 맛집을 소개해주세요!")
-                            .font(.suit(.medium, 14))
-                            .foregroundStyle(Color.grey6)
-                            .padding(.bottom, 18)
-                            .multilineTextAlignment(.center)
-                        Text("맛집 직접 등록하기")
-                            .font(.suit(.semiBold, 15))
-                            .foregroundStyle(Color.primary)
-                            .padding(.horizontal, 14)
-                            .padding(.vertical, 9)
-                            .background(Color.background)
-                            .clipShape(.rect(cornerRadius: 10))
-                    }
-                } else {
-                    VStack(alignment: .leading, spacing: 0) {
-                        HStack(spacing: 0) {
-                            Image(name: Common.clock)
-                            Text("00 : 13 : 43")
+        WithPerceptionTracking {
+            NavigationStack(path: $store.scope(state: \.path, action: \.path)) {
+                VStack(alignment: .leading, spacing: 0) {
+                    Text("인기 급등 맛집")
+                        .foregroundStyle(.black)
+                        .font(.suit(.bold, 20))
+                        .padding(.bottom, 16)
+                        .padding(.leading, 16)
+                    if store.popularReviews.count == 0 {
+                        VStack(alignment: .center, spacing: 0) {
+                            Image(name: Home.homeEmpty)
+                                .padding(.bottom, 12)
+                            Text("아직 주변의 맛집 리뷰가 없어요\n먼저 주변 아는 맛집을 소개해주세요!")
+                                .font(.suit(.medium, 14))
+                                .foregroundStyle(Color.grey6)
+                                .padding(.bottom, 18)
+                                .multilineTextAlignment(.center)
+                            Text("맛집 직접 등록하기")
+                                .font(.suit(.semiBold, 15))
                                 .foregroundStyle(Color.primary)
-                                .font(.suit(.bold, 18))
-                            Text("초 뒤에")
-                                .foregroundStyle(.black)
-                                .font(.suit(.bold, 18))
+                                .padding(.horizontal, 14)
+                                .padding(.vertical, 9)
+                                .background(Color.background)
+                                .clipShape(.rect(cornerRadius: 10))
                         }
-                        HStack(spacing: 4) {
-                            Text("인기 급등 맛집이 변경돼요.")
-                                .foregroundStyle(Color.black)
-                                .font(.suit(.regular, 18))
-                            Image(name: Common.info)
-                                .onTapGesture {
-                                    viewStore.send(.toolTipTapped)
-                                }
-                            Spacer()
-                            HStack {
-                                Text("전체보기")
-                                    .foregroundStyle(Color.grey6)
-                                    .font(.suit(.medium, 14))
-                                Image(name: Common.rightArrow)
-                                    .resizable()
-                                    .renderingMode(.template)
-                                    .frame(width: 16, height: 16)
-                                    .foregroundStyle(Color.grey6)
+                    } else {
+                        VStack(alignment: .leading, spacing: 0) {
+                            HStack(spacing: 0) {
+                                Image(name: Common.clock)
+                                Text("00 : 13 : 43")
+                                    .foregroundStyle(Color.primary)
+                                    .font(.suit(.bold, 18))
+                                Text("초 뒤에")
+                                    .foregroundStyle(.black)
+                                    .font(.suit(.bold, 18))
                             }
-                            .onTapGesture {
-                                viewStore.send(.viewAllTapped)
-                            }
-                        }
-                    }
-                    .padding(.horizontal, 16)
-                    .padding(.bottom, 24)
-                    
-                    TabView(selection: $currentpage) {
-                        ForEach(0..<viewStore.totalPage, id: \.self) { index in
-                            VStack {
-                                if index == 0 {
-                                    PlaceCell(review: viewStore.popularReviews[0], type: .medium)
-                                    LazyVGrid(columns: columns) {
-                                        if viewStore.popularReviews.count-1 >= 1 {
-                                            PlaceCell(review: viewStore.popularReviews[1], type: .small)
-                                        }
-                                        if viewStore.popularReviews.count-1 >= 2 {
-                                            PlaceCell(review: viewStore.popularReviews[2], type: .small)
-                                        }
+                            HStack(spacing: 4) {
+                                Text("인기 급등 맛집이 변경돼요.")
+                                    .foregroundStyle(Color.black)
+                                    .font(.suit(.regular, 18))
+                                Image(name: Common.info)
+                                    .onTapGesture {
+                                        store.send(.toolTipTapped)
                                     }
-                                } else {
-                                    LazyVGrid(columns: columns) {
-                                        ForEach(0..<4) { offset in
-                                            let reviewIndex = 3 + (index - 1) * 4 + offset
-                                            if viewStore.popularReviews.count-1 >= reviewIndex {
-                                                PlaceCell(review: viewStore.popularReviews[reviewIndex], type: .small)
+                                Spacer()
+                                NavigationLink(state: HomePopularFeature.Path.State.moveToAllReviewView()) {
+                                    HStack {
+                                        Text("전체보기")
+                                            .foregroundStyle(Color.grey6)
+                                            .font(.suit(.medium, 14))
+                                        Image(name: Common.rightArrow)
+                                            .resizable()
+                                            .renderingMode(.template)
+                                            .frame(width: 16, height: 16)
+                                            .foregroundStyle(Color.grey6)
+                                    }
+                                }
+                            }
+                        }
+                        .padding(.horizontal, 16)
+                        .padding(.bottom, 24)
+                        
+                        TabView(selection: $currentpage) {
+                            ForEach(0..<store.totalPage, id: \.self) { index in
+                                VStack {
+                                    if index == 0 {
+                                        NavigationLink(
+                                            state: HomePopularFeature.Path.State.moveToReviewDetailView(.init(id: store.popularReviews[0].id))
+                                        ) {
+                                            PlaceCell(review: store.popularReviews[0], type: .medium)
+                                        }
+                                        LazyVGrid(columns: columns) {
+                                            if store.popularReviews.count-1 >= 1 {
+                                                NavigationLink(
+                                                    state: HomePopularFeature.Path.State.moveToReviewDetailView(.init(id: store.popularReviews[1].id))
+                                                ) {
+                                                    PlaceCell(review: store.popularReviews[1], type: .small)
+                                                }
+                                            }
+                                            if store.popularReviews.count-1 >= 2 {
+                                                NavigationLink(
+                                                    state: HomePopularFeature.Path.State.moveToReviewDetailView(.init(id: store.popularReviews[2].id))
+                                                ) {
+                                                    PlaceCell(review: store.popularReviews[2], type: .small)
+                                                }
+                                            }
+                                        }
+                                    } else {
+                                        LazyVGrid(columns: columns) {
+                                            ForEach(0..<4) { offset in
+                                                let reviewIndex = 3 + (index - 1) * 4 + offset
+                                                if store.popularReviews.count-1 >= reviewIndex {
+                                                    NavigationLink(
+                                                        state: HomePopularFeature.Path.State.moveToReviewDetailView(.init(id: store.popularReviews[reviewIndex].id))
+                                                    ) {
+                                                        PlaceCell(review: store.popularReviews[reviewIndex], type: .small)
+                                                    }
+                                                }
                                             }
                                         }
                                     }
                                 }
+                                .padding(.horizontal, 16)
+                                .tag(index + 1)
+                                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
                             }
-                            .padding(.horizontal, 16)
-                            .tag(index + 1)
-                            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+                        }
+                        .frame(height: store.popularReviews.count == 1 ? 270 : 573, alignment: .center)
+                        .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
+                        .animation(.easeInOut, value: currentpage)
+                        // 탭뷰 페이징
+                        HStack(spacing: 0) {
+                            Spacer()
+                            Image(name: Home.previousPage)
+                                .padding(.trailing, 12)
+                                .onTapGesture {
+                                    if currentpage != 1 {
+                                        currentpage -= 1
+                                    }
+                                }
+                            Text("\(currentpage)")
+                                .foregroundStyle(Color.black)
+                                .font(.suit(.medium, 16))
+                            Text(" / \(store.state.totalPage)")
+                                .foregroundStyle(Color.grey8)
+                                .font(.suit(.medium, 16))
+                            Image(name: Home.nextPage)
+                                .padding(.leading, 12)
+                                .onTapGesture {
+                                    if currentpage != store.state.totalPage {
+                                        currentpage += 1
+                                    }
+                                }
+                            Spacer()
                         }
                     }
-                    .frame(height: viewStore.popularReviews.count == 1 ? 270 : 573, alignment: .center)
-                    .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
-                    .animation(.easeInOut, value: currentpage)
-                    // 탭뷰 페이징
-                    HStack(spacing: 0) {
-                        Spacer()
-                        Image(name: Home.previousPage)
-                            .padding(.trailing, 12)
-                            .onTapGesture {
-                                if currentpage != 1 {
-                                    currentpage -= 1
-                                }
-                            }
-                        Text("\(currentpage)")
-                            .foregroundStyle(Color.black)
-                            .font(.suit(.medium, 16))
-                        Text(" / \(viewStore.state.totalPage)")
-                            .foregroundStyle(Color.grey8)
-                            .font(.suit(.medium, 16))
-                        Image(name: Home.nextPage)
-                            .padding(.leading, 12)
-                            .onTapGesture {
-                                if currentpage != viewStore.state.totalPage {
-                                    currentpage += 1
-                                }
-                            }
-                        Spacer()
+                }
+                .onAppear {
+                    store.send(.requestPopularReviews)
+                }
+            } destination: { store in
+                switch store.state {
+                case .moveToReviewDetailView:
+                    if let _ = store.scope(state: \.moveToReviewDetailView, action: \.moveToReviewDetailView) {
+                        ReviewDetailView()
+                    }
+                case .moveToAllReviewView:
+                    if let _ = store.scope(state: \.moveToAllReviewView, action: \.moveToAllReviewView) {
+                        AllReviewView()
                     }
                 }
-            }
-            .onAppear {
-                viewStore.send(.requestPopularReviews)
             }
         }
     }

--- a/Cheffi/Module/Feature/Home/Popular/HomePopularView.swift
+++ b/Cheffi/Module/Feature/Home/Popular/HomePopularView.swift
@@ -168,8 +168,8 @@ struct HomePopularView: View {
             } destination: { store in
                 switch store.state {
                 case .moveToReviewDetailView:
-                    if let _ = store.scope(state: \.moveToReviewDetailView, action: \.moveToReviewDetailView) {
-                        ReviewDetailView()
+                    if let store = store.scope(state: \.moveToReviewDetailView, action: \.moveToReviewDetailView) {
+                        ReviewDetailView(store: store)
                     }
                 case .moveToAllReviewView:
                     if let _ = store.scope(state: \.moveToAllReviewView, action: \.moveToAllReviewView) {

--- a/Cheffi/Module/Feature/MainTabView.swift
+++ b/Cheffi/Module/Feature/MainTabView.swift
@@ -116,3 +116,10 @@ enum TabType: Int, CaseIterable {
 #Preview {
     MainTabView()
 }
+
+extension UINavigationController: ObservableObject, UIGestureRecognizerDelegate {
+    open override func viewDidLoad() {
+        super.viewDidLoad()
+        interactivePopGestureRecognizer?.delegate = nil
+    }
+}

--- a/Cheffi/Module/Feature/MainTabView.swift
+++ b/Cheffi/Module/Feature/MainTabView.swift
@@ -13,7 +13,7 @@ struct MainTabView: View {
     @State private var presentWriteView: Bool = false
     
     var body: some View {
-        NavigationView {
+        NavigationStack {
             TabView(selection: $selectedIndex) {
                 ForEach(TabType.allCases, id: \.self) { type in
                     getTabView(type: type)

--- a/Cheffi/Module/Feature/Review/ReviewDetailFeature.swift
+++ b/Cheffi/Module/Feature/Review/ReviewDetailFeature.swift
@@ -18,11 +18,13 @@ struct ReviewDetailFeature {
     struct State: Equatable {
         var id: Int?
         var reviewDetail: ReviewDetailModel?
+        var showToast: Bool = false
     }
     
     enum Action {
         case requestReviewDetail
         case reviewDetailResponse(Result<ReviewDetailResponse, Error>)
+        case toggleShowToast(Bool)
     }
     
     var body: some ReducerOf<Self> {
@@ -43,6 +45,10 @@ struct ReviewDetailFeature {
                 case .failure(let error):
                     print(error)
                 }
+                return .none
+                
+            case .toggleShowToast(let value):
+                state.showToast = value
                 return .none
             }
         }

--- a/Cheffi/Module/Feature/Review/ReviewDetailFeature.swift
+++ b/Cheffi/Module/Feature/Review/ReviewDetailFeature.swift
@@ -6,21 +6,44 @@
 //
 
 import Foundation
+import Combine
 import ComposableArchitecture
 
-struct ReviewDetailFeature: Reducer {
+@Reducer
+struct ReviewDetailFeature {
     
+    @Dependency(\.networkClient) var networkClient
+    
+    @ObservableState
     struct State: Equatable {
-        var id: Int
+        var id: Int?
+        var reviewDetail: ReviewDetailModel?
     }
     
-    enum Action: Equatable {
+    enum Action {
+        case requestReviewDetail
+        case reviewDetailResponse(Result<ReviewDetailResponse, Error>)
     }
     
     var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
+            case .requestReviewDetail:
+                return Effect.publisher {
+                    return networkClient
+                        .request(.reviewDetail(id: state.id ?? 0))
+                        .map { Action.reviewDetailResponse(.success($0)) }
+                        .catch { Just(Action.reviewDetailResponse(.failure($0))) }
+                }
                 
+            case .reviewDetailResponse(let response):
+                switch response {
+                case .success(let result):
+                    state.reviewDetail = result.data
+                case .failure(let error):
+                    print(error)
+                }
+                return .none
             }
         }
     }

--- a/Cheffi/Module/Feature/Review/ReviewDetailView.swift
+++ b/Cheffi/Module/Feature/Review/ReviewDetailView.swift
@@ -6,8 +6,16 @@
 //
 
 import SwiftUI
+import ComposableArchitecture
+import Kingfisher
+
+// TODO: 좋아요, 복사, 식당 평가, 팔로우 기능 구현
 
 struct ReviewDetailView: View {
+    
+    @Perception.Bindable var store: StoreOf<ReviewDetailFeature>
+    @Environment(\.dismiss) private var dismiss
+    
     private let screenWidth = UIWindow().screen.bounds.width
     
     @State private var selection = 0
@@ -26,228 +34,256 @@ struct ReviewDetailView: View {
     }
     
     var body: some View {
-        ZStack(alignment: .top) {
-            HStack {
-                Image(name: Common.leftArrow)
-                    .resizable()
-                    .renderingMode(.template)
-                    .foregroundStyle(navigationForegroundColor)
-                    .frame(width: 24, height: 24)
-                    .padding(8)
-                    .background(navigationBackgroundColor)
-                    .clipShape(.rect(cornerRadius: 20))
-                Spacer()
-                Image(name: Review.dots)
-                    .resizable()
-                    .renderingMode(.template)
-                    .foregroundStyle(navigationForegroundColor)
-                    .frame(width: 24, height: 24)
-                    .padding(8)
-                    .background(navigationBackgroundColor)
-                    .clipShape(.rect(cornerRadius: 20))
-            }
-            .padding(.horizontal, 16)
-            .padding(.bottom, 10)
-            .background(Color.white.opacity(navigationBarOpacity))
-            .zIndex(1)
-            
-            ScrollViewOffset(onOffsetChange: { offset in
-                scrollOffset = offset
-                scale = max(0, scrollOffset / screenWidth) + 1
-            }) {
-                ZStack {
-                    TabView(selection: $selection) {
-                        ForEach(0..<5) { _ in
-                            Image(name: Dummy.sample)
-                                .resizable()
-                                .scaledToFill()
-                                .frame(width: screenWidth * scale, height: screenWidth * scale)
-                                .clipped()
-                        }
-                    }
-                    .tabViewStyle(.page(indexDisplayMode: .never))
-                    VStack(alignment: .leading, spacing: 0) {
-                        Spacer()
-                        Text("취향일치 60%")
-                            .font(.suit(.bold, 14))
-                            .foregroundStyle(Color.white)
-                            .padding(EdgeInsets(top: 4, leading: 12, bottom: 4, trailing: 12))
-                            .background(Color.black.opacity(0.32))
-                            .clipShape(.rect(cornerRadius: 20))
-                            .padding(.bottom, 5)
-                        Text("그시절낭만의근본 경양식 돈가스")
-                            .font(.suit(.bold, 24))
-                            .foregroundStyle(Color.white)
-                            .lineLimit(2)
-                            .padding(.vertical, 5)
-                            .padding(.bottom, 3)
-                            .background(
-                                GeometryReader { geometry -> Color in
-                                    let maxY = geometry.frame(in: .global).midY
-                                    DispatchQueue.main.async {
-                                        navigationBarOpacity = max(0, (-maxY + 40) / 100)
-                                    }
-                                    return Color.clear
-                                }
-                            )
+        WithPerceptionTracking {
+            Group {
+                if let review = store.state.reviewDetail {
+                    ZStack(alignment: .top) {
                         HStack {
-                            Text("1시간 전")
-                                .font(.suit(.medium, 14))
-                                .foregroundStyle(Color.grey3)
+                            Image(name: Common.leftArrow)
+                                .resizable()
+                                .renderingMode(.template)
+                                .foregroundStyle(navigationForegroundColor)
+                                .frame(width: 24, height: 24)
+                                .padding(8)
+                                .background(navigationBackgroundColor)
+                                .clipShape(.rect(cornerRadius: 20))
+                                .onTapGesture {
+                                    dismiss()
+                                }
                             Spacer()
-                            HStack(spacing: 0) {
-                                Text("\(selection + 1)")
-                                    .font(.suit(.medium, 14))
-                                    .foregroundStyle(Color.white)
-                                Text("/\(imageCount)")
-                                    .font(.suit(.medium, 14))
-                                    .foregroundStyle(Color.grey1)
-                            }
-                            .padding(EdgeInsets(top: 4, leading: 10, bottom: 4, trailing: 10))
-                            .background(Color.black.opacity(0.32))
-                            .clipShape(.rect(cornerRadius: 20))
+                            Image(name: Review.dots)
+                                .resizable()
+                                .renderingMode(.template)
+                                .foregroundStyle(navigationForegroundColor)
+                                .frame(width: 24, height: 24)
+                                .padding(8)
+                                .background(navigationBackgroundColor)
+                                .clipShape(.rect(cornerRadius: 20))
                         }
-                        .padding(.bottom, 16)
-                    }
-                    .padding(.horizontal, 16)
-                }
-                .frame(width: screenWidth, height: screenWidth + (scrollOffset > 0 ? scrollOffset : 0))
-                .offset(y: (scrollOffset > 0 ? -scrollOffset : 0))
-                
-                Spacer().frame(height: 32)
-                
-                VStack(spacing: 0) {
-                    // 식당 이름
-                    HStack(alignment: .center) {
-                        Text("전풍호텔라운지")
-                            .font(.suit(.bold, 24))
-                            .foregroundStyle(Color.black)
-                        Spacer()
-                        Image(name: Common.emptyHeart)
-                    }
-                    .padding(.bottom, 32)
-                    // 리뷰 본문
-                    Text("문을 열자마자 시간 여행을 한다. 레트로함이 좀 느껴지는 수준을 넘어 진도준 선생님처럼 과거로 회귀한 듯 하다. 두툼한 돈카츠로 포화된 지금 찾기 힌든 근본의 한국 경양식 돈까스는 추억 보정까지 담아 더 맛이 깊어진다. 클래식하다. \n\n영화 촬영장 수준으로 과거를 표현한 매장은 돈까스가 나오기도 전에 어릴 적 엄마아빠 손을 잡고 돈까스를 썰어 먹던 추억을 불러온다. 배부르게 먹고 단순하게 행복해진 기억이 입혀져 음식이 더 기대되고, 먹고 나선 더 만족스러워진다.\n\n 돈까스가 나오자마자 벌써부터 눈이 배부르다. 확실하게 클래식함이 묻어나는 옛날 돈까스다. 얇고 넓게 펴져 큰 접시가 꽉 차도록 푸짐하게 담겨 있다. 돈까스를 다 썰은 후 먹는 것을 좋아한다면 넓은 돈까스 사이즈에 고생 좀 할 수도 있다. 부드럽지만 한참을 썰어야 해서 팔이 너덜너덜해진다.\n\n 옛날 돈까스이기 때문에 더 기본에 충실한 근본의 맛이 느껴진다. 겉은 소스에 절여졌음에도 바삭함이 유지되었고, 속은 순두부에 수렴하는 부드러운 느낌이었다. 한국 경양식 돈까스 탑티어다. 과일을 많이 사용하는지 소스가 새콤하며 느끼함이 전혀 없다. 밥과 샐러드, 돈까스를 비벼는 맛잘알들에게는 딱 맞을 소스다.\n\n 엄마가 ‘아들~ 돈까스 먹으러 가자’라고 하는 데에는 이유가 있다. 어릴 때에도 못 참았던 맛이 레트로한 공간과 어울려 깊어진다. 경양식계 클래식을 확실히 영접하고 나니 오므라이스와 매운 돈까스도 기대가 된다. 기회가 되면 꼭 재방문해야겠다.")
-                        .font(.suit(.regular, 16))
-                        .foregroundStyle(Color.grey8)
-                        .padding(.bottom, 32)
-                    // 메뉴
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("메뉴")
-                            .font(.suit(.bold, 18))
-                            .foregroundStyle(Color.black)
-                            .padding(.bottom, 8)
-                        ForEach(0..<5) { _ in
-                            HStack {
-                                Text("전풍 수제 돈까스")
+                        .padding(.horizontal, 16)
+                        .padding(.bottom, 10)
+                        .background(Color.white.opacity(navigationBarOpacity))
+                        .zIndex(1)
+                        
+                        ScrollViewOffset(onOffsetChange: { offset in
+                            scrollOffset = offset
+                            scale = max(0, scrollOffset / screenWidth) + 1
+                        }) {
+                            ZStack {
+                                TabView(selection: $selection) {
+                                    ForEach(0..<review.photos.count, id: \.self) { index in
+                                        Group {
+                                            if let url = URL(string: review.photos[index].photoUrl) {
+                                                KFImage(url)
+                                                    .resizable()
+                                            } else {
+                                                // TODO: 이미지 불러오지 못했을 때 UI 요청
+                                                Color.grey3
+                                            }
+                                        }
+                                        .scaledToFill()
+                                        .frame(width: screenWidth * scale, height: screenWidth * scale)
+                                        .clipped()
+                                    }
+                                }
+                                .tabViewStyle(.page(indexDisplayMode: .never))
+                                VStack(alignment: .leading, spacing: 0) {
+                                    Spacer()
+                                    Text("취향 \(review.matchedTagNum ?? 0)개 일치")
+                                        .font(.suit(.bold, 14))
+                                        .foregroundStyle(Color.white)
+                                        .padding(EdgeInsets(top: 4, leading: 12, bottom: 4, trailing: 12))
+                                        .background(Color.black.opacity(0.32))
+                                        .clipShape(.rect(cornerRadius: 20))
+                                        .padding(.bottom, 5)
+                                    Text(review.title)
+                                        .font(.suit(.bold, 24))
+                                        .foregroundStyle(Color.white)
+                                        .lineLimit(2)
+                                        .padding(.vertical, 5)
+                                        .padding(.bottom, 3)
+                                        .background(
+                                            GeometryReader { geometry -> Color in
+                                                let maxY = geometry.frame(in: .global).midY
+                                                DispatchQueue.main.async {
+                                                    navigationBarOpacity = max(0, (-maxY + 40) / 100)
+                                                }
+                                                return Color.clear
+                                            }
+                                        )
+                                    HStack {
+                                        Text(review.createdDate.timeAgo())
+                                            .font(.suit(.medium, 14))
+                                            .foregroundStyle(Color.grey3)
+                                        Spacer()
+                                        HStack(spacing: 0) {
+                                            Text("\(selection + 1)")
+                                                .font(.suit(.medium, 14))
+                                                .foregroundStyle(Color.white)
+                                            Text("/\(review.photos.count)")
+                                                .font(.suit(.medium, 14))
+                                                .foregroundStyle(Color.grey1)
+                                        }
+                                        .padding(EdgeInsets(top: 4, leading: 10, bottom: 4, trailing: 10))
+                                        .background(Color.black.opacity(0.32))
+                                        .clipShape(.rect(cornerRadius: 20))
+                                    }
+                                    .padding(.bottom, 16)
+                                }
+                                .padding(.horizontal, 16)
+                            }
+                            .frame(width: screenWidth, height: screenWidth + (scrollOffset > 0 ? scrollOffset : 0))
+                            .offset(y: (scrollOffset > 0 ? -scrollOffset : 0))
+                            
+                            Spacer().frame(height: 32)
+                            
+                            VStack(spacing: 0) {
+                                // 식당 이름
+                                HStack(alignment: .center) {
+                                    Text(review.restaurant.name)
+                                        .font(.suit(.bold, 24))
+                                        .foregroundStyle(Color.black)
+                                    Spacer()
+                                    Image(name: Common.emptyHeart)
+                                }
+                                .padding(.bottom, 32)
+                                // 리뷰 본문
+                                Text(review.text)
                                     .font(.suit(.regular, 16))
                                     .foregroundStyle(Color.grey8)
-                                    .frame(width: (screenWidth - 32) * 0.58, alignment: .leading)
-                                    .lineLimit(1)
-                                Spacer()
-                                Text("12,000원")
-                                    .font(.suit(.medium, 16))
-                                    .foregroundStyle(Color.grey7)
-                                    .frame(width: (screenWidth - 32) * 0.36, alignment: .trailing)
-                                    .lineLimit(1)
+                                    .padding(.bottom, 32)
+                                // 메뉴
+                                if review.menus.count != 0 {
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        Text("메뉴")
+                                            .font(.suit(.bold, 18))
+                                            .foregroundStyle(Color.black)
+                                            .padding(.bottom, 8)
+                                        ForEach(0..<review.menus.count, id: \.self) { index in
+                                            HStack {
+                                                Text(review.menus[index].name)
+                                                    .font(.suit(.regular, 16))
+                                                    .foregroundStyle(Color.grey8)
+                                                    .frame(width: (screenWidth - 32) * 0.58, alignment: .leading)
+                                                    .lineLimit(1)
+                                                Spacer()
+                                                Text("\(review.menus[index].price)원")
+                                                    .font(.suit(.medium, 16))
+                                                    .foregroundStyle(Color.grey7)
+                                                    .frame(width: (screenWidth - 32) * 0.36, alignment: .trailing)
+                                                    .lineLimit(1)
+                                            }
+                                        }
+                                    }
+                                    .padding(.bottom, 32)
+                                }
+                                // 위치
+                                VStack(alignment: .leading, spacing: 12) {
+                                    Text("위치")
+                                        .font(.suit(.bold, 18))
+                                        .foregroundStyle(Color.black)
+                                        .padding(.bottom, 6)
+                                    HStack {
+                                        Text(review.restaurant.address.fullRoadNameAddress)
+                                            .font(.suit(.regular, 16))
+                                            .foregroundStyle(Color.grey8)
+                                            .frame(width: (screenWidth - 32) * 0.88, alignment: .leading)
+                                            .lineLimit(1)
+                                        Spacer()
+                                        Text("복사")
+                                            .underline()
+                                            .font(.suit(.regular, 14))
+                                            .foregroundStyle(Color.init(hex: 0x34AFF7))
+                                    }
+                                }
+                                .padding(.bottom, 32)
+                                // 경계선
+                                Color.grey1.frame(height: 1)
+                                    .padding(.bottom, 32)
+                                // 작성자
+                                VStack(alignment: .leading, spacing: 16) {
+                                    Text("작성자")
+                                        .font(.suit(.bold, 18))
+                                        .foregroundStyle(Color.black)
+                                        .padding(.bottom, 6)
+                                    WriterRow(
+                                        imageUrl: review.writer.photoURL,
+                                        title: review.writer.nickname,
+                                        intro: review.writer.introduction,
+                                        isFollowed: true
+                                    )
+                                }
+                                .padding(.bottom, 32)
+                                // 평가
+                                VStack(alignment: .leading, spacing: 16) {
+                                    Text("이 식당 어떠셨나요?")
+                                        .font(.suit(.bold, 18))
+                                        .foregroundStyle(Color.black)
+                                        .padding(.bottom, 12)
+                                    HStack {
+                                        Spacer()
+                                        VStack(spacing: 8) {
+                                            Image(name: Review.normalGood)
+                                            Text("맛있어요")
+                                                .font(.suit(.regular, 12))
+                                                .foregroundStyle(Color.grey5)
+                                            Text("\(review.ratings.good)")
+                                                .font(.suit(.regular, 15))
+                                                .foregroundStyle(Color.grey5)
+                                        }
+                                        Spacer()
+                                        VStack(spacing: 8) {
+                                            Image(name: Review.normalSoso)
+                                            Text("평범해요")
+                                                .font(.suit(.regular, 12))
+                                                .foregroundStyle(Color.grey5)
+                                            Text("\(review.ratings.average)")
+                                                .font(.suit(.regular, 15))
+                                                .foregroundStyle(Color.grey5)
+                                        }
+                                        Spacer()
+                                        VStack(spacing: 8) {
+                                            Image(name: Review.normalBad)
+                                            Text("별로에요")
+                                                .font(.suit(.regular, 12))
+                                                .foregroundStyle(Color.grey5)
+                                            Text("\(review.ratings.bad)")
+                                                .font(.suit(.regular, 15))
+                                                .foregroundStyle(Color.grey5)
+                                        }
+                                        Spacer()
+                                    }
+                                    .padding(.vertical, 16)
+                                    .overlay(
+                                        RoundedRectangle(cornerRadius: 16)
+                                            .stroke(Color.grey1, lineWidth: 1)
+                                    )
+                                }
+                                .padding(.bottom, 32)
                             }
+                            .offset(y: scrollOffset <= 0 ? 0 : -scrollOffset)
+                            .padding(.horizontal, 16)
                         }
+                        .edgesIgnoringSafeArea(.top)
+                        .navigationBarHidden(true)
                     }
-                    .padding(.bottom, 32)
-                    // 위치
-                    VStack(alignment: .leading, spacing: 12) {
-                        Text("위치")
-                            .font(.suit(.bold, 18))
-                            .foregroundStyle(Color.black)
-                            .padding(.bottom, 6)
-                        HStack {
-                            Text("서울 성동구 무학봉28길 7 1층")
-                                .font(.suit(.regular, 16))
-                                .foregroundStyle(Color.grey8)
-                                .frame(width: (screenWidth - 32) * 0.88, alignment: .leading)
-                                .lineLimit(1)
-                            Spacer()
-                            Text("복사")
-                                .underline()
-                                .font(.suit(.regular, 14))
-                                .foregroundStyle(Color.init(hex: 0x34AFF7))
-                        }
-                    }
-                    .padding(.bottom, 32)
-                    // 경계선
-                    Color.grey1.frame(height: 1)
-                        .padding(.bottom, 32)
-                    // 작성자
-                    VStack(alignment: .leading, spacing: 16) {
-                        Text("작성자")
-                            .font(.suit(.bold, 18))
-                            .foregroundStyle(Color.black)
-                            .padding(.bottom, 6)
-                        WriterRow(
-                            imageUrl: String(),
-                            title: "김맛집",
-                            intro: "더 많은 맛집을 찾으러 여정을 따나는 중인 초보 맛집러",
-                            isFollowed: true
-                        )
-                    }
-                    .padding(.bottom, 32)
-                    // 평가
-                    VStack(alignment: .leading, spacing: 16) {
-                        Text("이 식당 어떠셨나요?")
-                            .font(.suit(.bold, 18))
-                            .foregroundStyle(Color.black)
-                            .padding(.bottom, 12)
-                        HStack {
-                            Spacer()
-                            VStack(spacing: 8) {
-                                Image(name: Review.normalGood)
-                                Text("맛있어요")
-                                    .font(.suit(.regular, 12))
-                                    .foregroundStyle(Color.grey5)
-                                Text("999+")
-                                    .font(.suit(.regular, 15))
-                                    .foregroundStyle(Color.grey5)
-                            }
-                            Spacer()
-                            VStack(spacing: 8) {
-                                Image(name: Review.normalSoso)
-                                Text("평범해요")
-                                    .font(.suit(.regular, 12))
-                                    .foregroundStyle(Color.grey5)
-                                Text("999+")
-                                    .font(.suit(.regular, 15))
-                                    .foregroundStyle(Color.grey5)
-                            }
-                            Spacer()
-                            VStack(spacing: 8) {
-                                Image(name: Review.normalBad)
-                                Text("별로에요")
-                                    .font(.suit(.regular, 12))
-                                    .foregroundStyle(Color.grey5)
-                                Text("999+")
-                                    .font(.suit(.regular, 15))
-                                    .foregroundStyle(Color.grey5)
-                            }
-                            Spacer()
-                        }
-                        .padding(.vertical, 16)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 16)
-                                .stroke(Color.grey1, lineWidth: 1)
-                        )
-                    }
-                    .padding(.bottom, 32)
+                } else {
+                    ProgressView()
+                        .navigationBarHidden(true)
                 }
-                .offset(y: scrollOffset <= 0 ? 0 : -scrollOffset)
-                .padding(.horizontal, 16)
             }
-            .edgesIgnoringSafeArea(.top)
-            .navigationBarHidden(true)
+            .onAppear {
+                store.send(.requestReviewDetail)
+            }
         }
     }
 }
 
 
 #Preview {
-    ReviewDetailView()
+    ReviewDetailView(store: .init(
+        initialState: ReviewDetailFeature.State()) {
+            ReviewDetailFeature()
+        }
+    )
 }

--- a/Cheffi/Module/Feature/Review/ReviewDetailView.swift
+++ b/Cheffi/Module/Feature/Review/ReviewDetailView.swift
@@ -194,6 +194,10 @@ struct ReviewDetailView: View {
                                             .underline()
                                             .font(.suit(.regular, 14))
                                             .foregroundStyle(Color.init(hex: 0x34AFF7))
+                                            .onTapGesture {
+                                                UIPasteboard.general.string = review.restaurant.address.fullRoadNameAddress
+                                                store.send(.toggleShowToast(true))
+                                            }
                                     }
                                 }
                                 .padding(.bottom, 32)
@@ -266,6 +270,11 @@ struct ReviewDetailView: View {
                         }
                         .edgesIgnoringSafeArea(.top)
                         .navigationBarHidden(true)
+                        .toast(
+                            message: "주소가 클립보드에 복사되었습니다.",
+                            type: .check,
+                            isShowing: $store.showToast.sending(\.toggleShowToast)
+                        )
                     }
                 } else {
                     ProgressView()

--- a/Cheffi/Module/Feature/Review/ReviewDetailView.swift
+++ b/Cheffi/Module/Feature/Review/ReviewDetailView.swift
@@ -242,6 +242,7 @@ struct ReviewDetailView: View {
                 .padding(.horizontal, 16)
             }
             .edgesIgnoringSafeArea(.top)
+            .navigationBarHidden(true)
         }
     }
 }

--- a/Cheffi/Network/EndPoint/RestRouter+EndPoint.swift
+++ b/Cheffi/Network/EndPoint/RestRouter+EndPoint.swift
@@ -49,6 +49,7 @@ extension RestRouter: EndPoint {
         case .avatarsNickname,
              .popularReviews,
              .cheffiPlace,
+             .reviewDetail,
              .tags,
              .testSessionIssue,
              .testAuth:

--- a/Cheffi/Network/EndPoint/RestRouter+Path.swift
+++ b/Cheffi/Network/EndPoint/RestRouter+Path.swift
@@ -18,6 +18,8 @@ extension RestRouter {
             return "/api/v1/reviews/areas"
         case .cheffiPlace:
             return "/api/v1/reviews/areas/tags"
+        case .reviewDetail:
+            return "/api/v1/reviews"
         case .tags:
             return "/api/v1/tags"
         case .testUpload:

--- a/Cheffi/Network/EndPoint/RestRouter.swift
+++ b/Cheffi/Network/EndPoint/RestRouter.swift
@@ -18,6 +18,7 @@ enum RestRouter {
     // - MARK: 홈
     case popularReviews(province: String, city: String, cursor: Int, size: Int)
     case cheffiPlace(province: String, city: String, cursor: Int, size: Int, tag_id: Int)
+    case reviewDetail(id: Int)
     
     // - MARK: 태그
     case tags(type: String)


### PR DESCRIPTION
## 🌁 Background
- 

## 📱 Screenshot
![Simulator Screen Recording - iPhone 15 - 2024-07-10 at 16 24 26](https://github.com/Cheffi-GitHub/Cheffi-iOS/assets/60253668/b89c2b88-f597-4d83-8f98-a41e74a174e8)


## 👩‍💻 Contents
- 리뷰 상세 화면 api 연동
- 주소 복사 기능 구현
- Toast Message 기능 구현

ToastMessage.swift
- 피그마 상에서 Toast Message의 종류는 총 3가지 입니다.

    enum ToastType {
        case normal
        case check
        case cancellable
    }

- 이벤트 취소 이벤트를 받기 위한 escaping closure를 사용했습니다.

    let message: String
    let type: ToastType
    @Binding var isShowing: Bool
    var onCancel: (() -> Void)?

- 각 뷰에서 관리하도록 구현했습니다.

     .toast(
         message: "주소가 클립보드에 복사되었습니다.",
         type: .check,
         isShowing: $store.showToast.sending(\.toggleShowToast)
        )

## ✅ Testing
- 


## 📝 Review Note
- 북마크, 식당 평가, 팔로우 기능은 로그인 구현 후에 추가로 작업하겠습니다!

## 📣 Related Issue
-