### PR TITLE
[FEAT] Server Error Response 모델링, 파싱 구현

### DIFF
--- a/Cheffi.xcodeproj/project.pbxproj
+++ b/Cheffi.xcodeproj/project.pbxproj
@@ -58,6 +58,9 @@
 		A611D9D32C187D7800ABF38C /* RestRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A611D9D22C187D7800ABF38C /* RestRouter.swift */; };
 		A611D9D52C187D8400ABF38C /* NetworkClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A611D9D42C187D8400ABF38C /* NetworkClient.swift */; };
 		A611D9DB2C187F6000ABF38C /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = A611D9DA2C187F6000ABF38C /* Alamofire */; };
+		A61FC3CA2C3D689200C732C6 /* RestErrorResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = A61FC3C92C3D689200C732C6 /* RestErrorResponse.swift */; };
+		A61FC3CD2C3D68D900C732C6 /* CheffiError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A61FC3CC2C3D68D900C732C6 /* CheffiError.swift */; };
+		A61FC3CF2C3D68E200C732C6 /* DataRequest+Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = A61FC3CE2C3D68E200C732C6 /* DataRequest+Response.swift */; };
 		A67677F32C1738EF0089A269 /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = A67677F22C1738EF0089A269 /* AppEnvironment.swift */; };
 		A688B0AB2C29B68600E4E3A2 /* RestResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = A688B0AA2C29B68600E4E3A2 /* RestResponse.swift */; };
 		A688B0AD2C29B68E00E4E3A2 /* LoginKakaoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A688B0AC2C29B68E00E4E3A2 /* LoginKakaoModel.swift */; };
@@ -150,6 +153,9 @@
 		A611D9D02C187D6500ABF38C /* EndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndPoint.swift; sourceTree = "<group>"; };
 		A611D9D22C187D7800ABF38C /* RestRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestRouter.swift; sourceTree = "<group>"; };
 		A611D9D42C187D8400ABF38C /* NetworkClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkClient.swift; sourceTree = "<group>"; };
+		A61FC3C92C3D689200C732C6 /* RestErrorResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestErrorResponse.swift; sourceTree = "<group>"; };
+		A61FC3CC2C3D68D900C732C6 /* CheffiError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheffiError.swift; sourceTree = "<group>"; };
+		A61FC3CE2C3D68E200C732C6 /* DataRequest+Response.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DataRequest+Response.swift"; sourceTree = "<group>"; };
 		A67677E92C1730C60089A269 /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		A67677F22C1738EF0089A269 /* AppEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEnvironment.swift; sourceTree = "<group>"; };
 		A67677F62C1740230089A269 /* Secrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
@@ -291,6 +297,7 @@
 		548BC0612C086AD500A73F66 /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				A61FC3CB2C3D68C600C732C6 /* Component */,
 				A6F5E6FC2C280AF60053C2E8 /* EndPoint */,
 				A611D9D42C187D8400ABF38C /* NetworkClient.swift */,
 				A6F5E6C72C1B21630053C2E8 /* NetworkRequestInterceptor.swift */,
@@ -461,6 +468,15 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		A61FC3CB2C3D68C600C732C6 /* Component */ = {
+			isa = PBXGroup;
+			children = (
+				A61FC3CC2C3D68D900C732C6 /* CheffiError.swift */,
+				A61FC3CE2C3D68E200C732C6 /* DataRequest+Response.swift */,
+			);
+			path = Component;
+			sourceTree = "<group>";
+		};
 		A67677F82C1740790089A269 /* Environment */ = {
 			isa = PBXGroup;
 			children = (
@@ -475,6 +491,7 @@
 			isa = PBXGroup;
 			children = (
 				A688B0AA2C29B68600E4E3A2 /* RestResponse.swift */,
+				A61FC3C92C3D689200C732C6 /* RestErrorResponse.swift */,
 				A688B0AC2C29B68E00E4E3A2 /* LoginKakaoModel.swift */,
 				54F217AA2C2D2F1B00892DBD /* ReviewModel.swift */,
 				54E285F92C2FE28700AD7939 /* TagsModel.swift */,
@@ -702,6 +719,7 @@
 				54073B852C0D908200597973 /* NavigationBarView.swift in Sources */,
 				A6F5E6FB2C280AD00053C2E8 /* RestRouter+Path.swift in Sources */,
 				A6F5E6FE2C284D350053C2E8 /* TokenStorageEventMonitor.swift in Sources */,
+				A61FC3CF2C3D68E200C732C6 /* DataRequest+Response.swift in Sources */,
 				549B1F8F2C0607C7005C9432 /* CheffiApp.swift in Sources */,
 				540BE9B42C231036009180AE /* WriterRow.swift in Sources */,
 				54073B882C0D913800597973 /* NavigationBarFeature.swift in Sources */,
@@ -719,6 +737,7 @@
 				541930532C3D7B200080CA57 /* Writer.swift in Sources */,
 				54E285FA2C2FE28700AD7939 /* TagsModel.swift in Sources */,
 				541930512C3D7B160080CA57 /* Address.swift in Sources */,
+				A61FC3CD2C3D68D900C732C6 /* CheffiError.swift in Sources */,
 				A611D9D32C187D7800ABF38C /* RestRouter.swift in Sources */,
 				A6F5E6F92C280AC00053C2E8 /* RestRouter+EndPoint.swift in Sources */,
 				A688B0B02C29B6A800E4E3A2 /* Authority.swift in Sources */,
@@ -737,6 +756,7 @@
 				54073B8A2C0D932D00597973 /* HomePopularView.swift in Sources */,
 				A688B0AD2C29B68E00E4E3A2 /* LoginKakaoModel.swift in Sources */,
 				A6F5E6CE2C1B2BA80053C2E8 /* DataExtension.swift in Sources */,
+				A61FC3CA2C3D689200C732C6 /* RestErrorResponse.swift in Sources */,
 				A67677F32C1738EF0089A269 /* AppEnvironment.swift in Sources */,
 				540BE9B02C22C607009180AE /* ReviewDetailFeature.swift in Sources */,
 			);

--- a/Cheffi.xcodeproj/project.pbxproj
+++ b/Cheffi.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		A61FC3CA2C3D689200C732C6 /* RestErrorResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = A61FC3C92C3D689200C732C6 /* RestErrorResponse.swift */; };
 		A61FC3CD2C3D68D900C732C6 /* CheffiError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A61FC3CC2C3D68D900C732C6 /* CheffiError.swift */; };
 		A61FC3CF2C3D68E200C732C6 /* DataRequest+Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = A61FC3CE2C3D68E200C732C6 /* DataRequest+Response.swift */; };
+		A61FC3D22C3D849700C732C6 /* AnyCodable in Frameworks */ = {isa = PBXBuildFile; productRef = A61FC3D12C3D849700C732C6 /* AnyCodable */; };
 		A67677F32C1738EF0089A269 /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = A67677F22C1738EF0089A269 /* AppEnvironment.swift */; };
 		A688B0AB2C29B68600E4E3A2 /* RestResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = A688B0AA2C29B68600E4E3A2 /* RestResponse.swift */; };
 		A688B0AD2C29B68E00E4E3A2 /* LoginKakaoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A688B0AC2C29B68E00E4E3A2 /* LoginKakaoModel.swift */; };
@@ -185,6 +186,7 @@
 				A611D9DB2C187F6000ABF38C /* Alamofire in Frameworks */,
 				54F217B22C2D685400892DBD /* Kingfisher in Frameworks */,
 				A6F5E6DD2C23213D0053C2E8 /* KakaoSDK in Frameworks */,
+				A61FC3D22C3D849700C732C6 /* AnyCodable in Frameworks */,
 				A6F5E6E12C23215B0053C2E8 /* KakaoSDKUser in Frameworks */,
 				A6F5E6E32C23215F0053C2E8 /* KakaoSDKCommon in Frameworks */,
 				A6F5E6DF2C23213F0053C2E8 /* KakaoSDKAuth in Frameworks */,
@@ -576,6 +578,7 @@
 				A6F5E6E02C23215B0053C2E8 /* KakaoSDKUser */,
 				A6F5E6E22C23215F0053C2E8 /* KakaoSDKCommon */,
 				54F217B12C2D685400892DBD /* Kingfisher */,
+				A61FC3D12C3D849700C732C6 /* AnyCodable */,
 			);
 			productName = Cheffi;
 			productReference = 549B1F8B2C0607C7005C9432 /* Cheffi.app */;
@@ -654,6 +657,7 @@
 				A611D9D82C187F5600ABF38C /* XCRemoteSwiftPackageReference "Alamofire" */,
 				A6F5E6DB2C2321360053C2E8 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */,
 				54F217B02C2D685400892DBD /* XCRemoteSwiftPackageReference "Kingfisher" */,
+				A61FC3D02C3D848B00C732C6 /* XCRemoteSwiftPackageReference "AnyCodable" */,
 			);
 			productRefGroup = 549B1F8C2C0607C7005C9432 /* Products */;
 			projectDirPath = "";
@@ -1132,6 +1136,14 @@
 				version = 5.9.0;
 			};
 		};
+		A61FC3D02C3D848B00C732C6 /* XCRemoteSwiftPackageReference "AnyCodable" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Flight-School/AnyCodable";
+			requirement = {
+				kind = exactVersion;
+				version = 0.6.0;
+			};
+		};
 		A6F5E6DB2C2321360053C2E8 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/kakao/kakao-ios-sdk";
@@ -1157,6 +1169,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = A611D9D82C187F5600ABF38C /* XCRemoteSwiftPackageReference "Alamofire" */;
 			productName = Alamofire;
+		};
+		A61FC3D12C3D849700C732C6 /* AnyCodable */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A61FC3D02C3D848B00C732C6 /* XCRemoteSwiftPackageReference "AnyCodable" */;
+			productName = AnyCodable;
 		};
 		A6F5E6DC2C23213D0053C2E8 /* KakaoSDK */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Cheffi.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Cheffi.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "f236339b41d3e320930b0a28d13f828a82d3ccc551ce43c1fb2fa13a15398249",
+  "originHash" : "b99f308e98cee6d886dff1d52b64c2a397504d07bb084fa453b4a7d483ed8065",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -8,6 +8,15 @@
       "state" : {
         "revision" : "723fa5a6c65812aec4a0d7cc432ee198883b6e00",
         "version" : "5.9.0"
+      }
+    },
+    {
+      "identity" : "anycodable",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Flight-School/AnyCodable",
+      "state" : {
+        "revision" : "876d162385e9862ae8b3c8d65dc301312b040005",
+        "version" : "0.6.0"
       }
     },
     {

--- a/Cheffi/Module/Component/Models/RestErrorResponse.swift
+++ b/Cheffi/Module/Component/Models/RestErrorResponse.swift
@@ -1,0 +1,20 @@
+//
+//  RestErrorResponse.swift
+//  Cheffi
+//
+//  Created by 이서준 on 7/9/24.
+//
+
+import Foundation
+
+struct RestErrorResponse: Codable, Error {
+    var errorCode: String?
+    var errorMessage: String?
+    // TODO: Cheffi Server Error Response 규격에 맞추어 data 타입 고정
+    //var data: T?
+    
+    enum CodingKeys: String, CodingKey {
+        case errorCode = "error_code"
+        case errorMessage = "error_message"
+    }
+}

--- a/Cheffi/Module/Component/Models/RestErrorResponse.swift
+++ b/Cheffi/Module/Component/Models/RestErrorResponse.swift
@@ -6,15 +6,16 @@
 //
 
 import Foundation
+import AnyCodable
 
 struct RestErrorResponse: Codable, Error {
     var errorCode: String?
     var errorMessage: String?
-    // TODO: Cheffi Server Error Response 규격에 맞추어 data 타입 고정
-    //var data: T?
+    var data: [String: AnyCodable]?
     
     enum CodingKeys: String, CodingKey {
         case errorCode = "error_code"
         case errorMessage = "error_message"
+        case data = "data"
     }
 }

--- a/Cheffi/Module/Feature/Home/Popular/HomePopularFeature.swift
+++ b/Cheffi/Module/Feature/Home/Popular/HomePopularFeature.swift
@@ -27,7 +27,7 @@ struct HomePopularFeature {
     
     enum Action {
         case requestPopularReviews
-        case popularReviewsResponse(Result<ReviewResponse, AFError>)
+        case popularReviewsResponse(Result<ReviewResponse, CheffiError>)
         case toolTipTapped
         case path(StackAction<Path.State, Path.Action>)
     }

--- a/Cheffi/Network/Component/CheffiError.swift
+++ b/Cheffi/Network/Component/CheffiError.swift
@@ -1,0 +1,15 @@
+//
+//  CheffiError.swift
+//  Cheffi
+//
+//  Created by 이서준 on 7/9/24.
+//
+
+import Foundation
+
+enum CheffiError: Error {
+    case unknown(message: String)
+    case invaildSpec(message: String)
+    case internalServerError(statusCode: Int)
+    case failureResponse(statusCode: Int, error: RestErrorResponse)
+}

--- a/Cheffi/Network/Component/CheffiError.swift
+++ b/Cheffi/Network/Component/CheffiError.swift
@@ -11,5 +11,7 @@ enum CheffiError: Error {
     case unknown(message: String)
     case invaildSpec(message: String)
     case internalServerError(statusCode: Int)
-    case failureResponse(statusCode: Int, error: RestErrorResponse)
+    case failedParsingErrorData(statusCode: Int)
+    case failureWithErrorData(statusCode: Int, error: Data)
+    case failureWithParsedError(statusCode: Int, error: RestErrorResponse)
 }

--- a/Cheffi/Network/Component/DataRequest+Response.swift
+++ b/Cheffi/Network/Component/DataRequest+Response.swift
@@ -1,0 +1,47 @@
+//
+//  DataRequest+Response.swift
+//  Cheffi
+//
+//  Created by 이서준 on 7/9/24.
+//
+
+import Foundation
+import Combine
+import Alamofire
+
+extension DataRequest {
+    func cheffiResponseDecodable<T: Decodable>(
+        of type: T.Type = T.self,
+        queue: DispatchQueue = .main,
+        decoder: DataDecoder = JSONDecoder()
+    ) -> AnyPublisher<T, CheffiError> {
+        return Future { promise in
+            self.responseDecodable(of: type, queue: queue, decoder: decoder) { response in
+                switch response.result {
+                case .success(let data):
+                    promise(.success(data))
+                case .failure(let error):
+                    guard let statusCode = response.response?.statusCode else {
+                        promise(.failure(.unknown(message: error.localizedDescription)))
+                        return
+                    }
+                    
+                    if let data = response.data,
+                       let errorResponse = try? JSONDecoder().decode(RestErrorResponse.self, from: data) {
+                        promise(.failure(.failureResponse(statusCode: statusCode, error: errorResponse)))
+                    }
+                    else if error.isResponseSerializationError {
+                        promise(.failure(.invaildSpec(message: error.localizedDescription)))
+                    }
+                    else if (500 ..< 600).contains(statusCode) {
+                        promise(.failure(.internalServerError(statusCode: statusCode)))
+                    }
+                    else {
+                        promise(.failure(.unknown(message: error.localizedDescription)))
+                    }
+                }
+            }
+        }
+        .eraseToAnyPublisher()
+    }
+}

--- a/Cheffi/Network/NetworkClient.swift
+++ b/Cheffi/Network/NetworkClient.swift
@@ -31,6 +31,7 @@ struct NetworkClient {
         return session.request(endPoint)
             .validate()
             .cheffiResponseDecodable(of: Value.self)
+            .mapErrorResponse()
             .subscribe(on: queue)
             .receive(on: DispatchQueue.main)
             .eraseToAnyPublisher()

--- a/Cheffi/Network/NetworkClient.swift
+++ b/Cheffi/Network/NetworkClient.swift
@@ -54,7 +54,7 @@ extension NetworkClient: DependencyKey {
             session: Session(
                 configuration: configuration,
                 interceptor: NetworkRequestInterceptor(
-                    limit: 30,
+                    limit: 3,
                     delay: 3
                 ),
                 eventMonitors: [

--- a/Cheffi/Network/NetworkClient.swift
+++ b/Cheffi/Network/NetworkClient.swift
@@ -27,12 +27,10 @@ struct NetworkClient {
         self.queue = queue
     }
     
-    func request<Value: Codable>(_ endPoint: RestRouter) -> AnyPublisher<Value, AFError> {
+    func request<Value: Codable>(_ endPoint: RestRouter) -> AnyPublisher<Value, CheffiError> {
         return session.request(endPoint)
             .validate()
-            // TODO: Progress 핸들링 -> Loading indicator 표시
-            .publishDecodable(type: Value.self)
-            .value()
+            .cheffiResponseDecodable(of: Value.self)
             .subscribe(on: queue)
             .receive(on: DispatchQueue.main)
             .eraseToAnyPublisher()

--- a/Cheffi/Network/NetworkRequestInterceptor.swift
+++ b/Cheffi/Network/NetworkRequestInterceptor.swift
@@ -51,5 +51,9 @@ struct NetworkRequestInterceptor: RequestInterceptor {
         
         // TODO: 재시도 불가능 케이스 수집
         // ex) 접근 권한 없음, 토큰 만료 등
+        
+        // TODO: retry(_: ) 메서드 제거, Custom Alert/UserAction을 통한 retry flow 구현
+        
+        completion(.retry)
     }
 }


### PR DESCRIPTION
## 🌁 Background
1. API Request 결과가 실패인 경우 정상적인 네트워킹이 이루어지지 않는 문제 수정 필요
2. Server Error Response 규격 모델링 구현과 JSON 파싱 필요


## 👩‍💻 Contents

1. API Request Failure Reason을 명시적으로 확인할 수 있는 CheffiError를 구현하였습니다.
**unknown**: CheffiError case에 고려되지 않은 직접 에러 발생 원인 점검이 필요한 경우
**invaildSpec**: Response Data의 직렬화에 실패한 경우(서버 규격과 일치하지 않음)
**internalServerError**: StatusCode가 500~599인 서버단에서 에러 원인 점검이 필요한 경우
**failureWithErrorData**: API Request 결과가 실패이고, Response Data를 포함하는 경우
**failedParsingErrorData**: failureWithErrorData의 Response Data를 RestErrorResponse 모델로 파싱 실패한 경우
**failureWithParsedError**: failureWithErrorData의 Response Data를 RestErrorResponse 모델로 파싱 성공한 경우

```swift
enum CheffiError: Error {
    case unknown(message: String)
    case invaildSpec(message: String)
    case internalServerError(statusCode: Int)
    case failedParsingErrorData(statusCode: Int)
    case failureWithErrorData(statusCode: Int, error: Data)
    case failureWithParsedError(statusCode: Int, error: RestErrorResponse)
}
```

2. DataRequest+Response.swift
NetworkClient.request(_:) 메서드를 체이닝 방식(혹은 선언형 프로그래밍)으로 표현하기 위한 Extension.

`의도`
cheffiResponseDecodable(_:)` 메서드를 활용하여 1차적으로 API Request를 실패한 원인을 분류하고,
mapErrorResponse() 메서드에서는 Error Response Data를 RestErrorResponse 모델로 컨버팅(파싱)합니다.

```swift
func request<Value: Codable>(_ endPoint: RestRouter) -> AnyPublisher<Value, CheffiError> {
    return session.request(endPoint)
        .validate()
        .cheffiResponseDecodable(of: Value.self)
        .mapErrorResponse()
        .subscribe(on: queue)
        .receive(on: DispatchQueue.main)
        .eraseToAnyPublisher()
}
```

3. AnyCodable 라이브러리를 활용한 RestErrorResponse 구현
data의 타입을 Generic으로 설정할 경우 연관된 모든 객체가 명확한 타입 설정을 위해 <SomeType>이 추가되며, 가독성과 코드 추적을 하향시킴
data를 포함하여 Error Response를 반환하는 API는 극소수이기 때문에, AnyCodable을 채용하여 data를 dictionary 타입으로 파싱하여, **data 객체의 활용이 필요한 피쳐에서 dictionary로 파싱된 data를 key/value 방식으로 접근하여 사용하는 방식**으로 설계

단, 서버 규격에 변동사항 또는 고려되지 못한 상황에 의해 dictionary value에 접근하다가 앱 충돌이 발생하는 상황을 경계해야할것!
(= 항상 안전하게 optional value로 다루기!)


## 📝 Review Note
- CheffiError와 DataRequest+Response를 프로젝트내의 어느곳에 위치시켜야 할지 고민하다가..
Network 모듈과 더 밀접하게 관련이 되어있고, NetworkClient.request(_:) 메서드를 보조하는 역할이기에 Network 디렉토리에 위치시켰습니다!