### PR TITLE
Feat/all review

### DIFF
--- a/Cheffi.xcodeproj/project.pbxproj
+++ b/Cheffi.xcodeproj/project.pbxproj
@@ -14,7 +14,7 @@
 		54073B852C0D908200597973 /* NavigationBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54073B842C0D908200597973 /* NavigationBarView.swift */; };
 		54073B882C0D913800597973 /* NavigationBarFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54073B872C0D913800597973 /* NavigationBarFeature.swift */; };
 		54073B8A2C0D932D00597973 /* HomePopularView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54073B892C0D932D00597973 /* HomePopularView.swift */; };
-		54073B8C2C0D98E500597973 /* PlaceCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54073B8B2C0D98E400597973 /* PlaceCell.swift */; };
+		54073B8C2C0D98E500597973 /* ReviewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54073B8B2C0D98E400597973 /* ReviewCell.swift */; };
 		540BE9B02C22C607009180AE /* ReviewDetailFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 540BE9AF2C22C607009180AE /* ReviewDetailFeature.swift */; };
 		540BE9B42C231036009180AE /* WriterRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 540BE9B32C231036009180AE /* WriterRow.swift */; };
 		541930492C3D49640080CA57 /* AllReviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 541930482C3D49640080CA57 /* AllReviewView.swift */; };
@@ -103,7 +103,7 @@
 		54073B842C0D908200597973 /* NavigationBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationBarView.swift; sourceTree = "<group>"; };
 		54073B872C0D913800597973 /* NavigationBarFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationBarFeature.swift; sourceTree = "<group>"; };
 		54073B892C0D932D00597973 /* HomePopularView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePopularView.swift; sourceTree = "<group>"; };
-		54073B8B2C0D98E400597973 /* PlaceCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceCell.swift; sourceTree = "<group>"; };
+		54073B8B2C0D98E400597973 /* ReviewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewCell.swift; sourceTree = "<group>"; };
 		540BE9AF2C22C607009180AE /* ReviewDetailFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDetailFeature.swift; sourceTree = "<group>"; };
 		540BE9B12C22C853009180AE /* ScrollViewOffset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollViewOffset.swift; sourceTree = "<group>"; };
 		540BE9B32C231036009180AE /* WriterRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriterRow.swift; sourceTree = "<group>"; };
@@ -303,7 +303,7 @@
 		548BC0622C086ADE00A73F66 /* View */ = {
 			isa = PBXGroup;
 			children = (
-				54073B8B2C0D98E400597973 /* PlaceCell.swift */,
+				54073B8B2C0D98E400597973 /* ReviewCell.swift */,
 				540BE9B32C231036009180AE /* WriterRow.swift */,
 			);
 			path = View;
@@ -713,7 +713,7 @@
 				541930592C3D8BEC0080CA57 /* StringExtension.swift in Sources */,
 				A611D9D12C187D6500ABF38C /* EndPoint.swift in Sources */,
 				54F217A92C2BC42A00892DBD /* ScrollViewOffset.swift in Sources */,
-				54073B8C2C0D98E500597973 /* PlaceCell.swift in Sources */,
+				54073B8C2C0D98E500597973 /* ReviewCell.swift in Sources */,
 				5419304D2C3D798A0080CA57 /* ReviewDetailModel.swift in Sources */,
 				543F0AE62C10264800DFBDB1 /* HomeCheffiStoryFeature.swift in Sources */,
 				541930532C3D7B200080CA57 /* Writer.swift in Sources */,

--- a/Cheffi/Application/Resource/Assets.xcassets/normalCollapse.imageset/Contents.json
+++ b/Cheffi/Application/Resource/Assets.xcassets/normalCollapse.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "normalCollapse.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cheffi/Application/Resource/Assets.xcassets/normalCollapse.imageset/normalCollapse.svg
+++ b/Cheffi/Application/Resource/Assets.xcassets/normalCollapse.imageset/normalCollapse.svg
@@ -1,0 +1,14 @@
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_4901_5665)">
+<path d="M7.66667 1H1V7.66667H7.66667V1Z" stroke="#9E9E9E" stroke-width="1.5" stroke-linejoin="round"/>
+<path d="M16.9999 1H10.3333V7.66667H16.9999V1Z" stroke="#9E9E9E" stroke-width="1.5" stroke-linejoin="round"/>
+<path d="M7.66667 10.334H1V17.0007H7.66667V10.334Z" stroke="#9E9E9E" stroke-width="1.5" stroke-linejoin="round"/>
+<path d="M13.6666 17.0007H10.3333V10.334H16.9999V13.6673" stroke="#9E9E9E" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M16.3333 17.1667C16.7936 17.1667 17.1667 16.7936 17.1667 16.3333C17.1667 15.8731 16.7936 15.5 16.3333 15.5C15.8731 15.5 15.5 15.8731 15.5 16.3333C15.5 16.7936 15.8731 17.1667 16.3333 17.1667Z" fill="#9E9E9E"/>
+</g>
+<defs>
+<clipPath id="clip0_4901_5665">
+<rect width="17.5" height="17.5" fill="white" transform="translate(0.333252 0.333984)"/>
+</clipPath>
+</defs>
+</svg>

--- a/Cheffi/Application/Resource/Assets.xcassets/normalExpand.imageset/Contents.json
+++ b/Cheffi/Application/Resource/Assets.xcassets/normalExpand.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "normalExpand.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cheffi/Application/Resource/Assets.xcassets/normalExpand.imageset/normalExpand.svg
+++ b/Cheffi/Application/Resource/Assets.xcassets/normalExpand.imageset/normalExpand.svg
@@ -1,0 +1,14 @@
+<svg width="16" height="17" viewBox="0 0 16 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_4901_6871)">
+<path d="M1.3335 15.334L5.3335 11.334" stroke="#9E9E9E" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M10.6665 5.33398L14.6665 1.33398" stroke="#9E9E9E" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M4.6665 16H0.666504V12" stroke="#9E9E9E" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M11.3335 0.666016H15.3335V4.66602" stroke="#9E9E9E" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7.99984 9.33268C8.73622 9.33268 9.33317 8.73573 9.33317 7.99935C9.33317 7.26297 8.73622 6.66602 7.99984 6.66602C7.26346 6.66602 6.6665 7.26297 6.6665 7.99935C6.6665 8.73573 7.26346 9.33268 7.99984 9.33268Z" fill="#9E9E9E"/>
+</g>
+<defs>
+<clipPath id="clip0_4901_6871">
+<rect width="16" height="16.6667" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/Cheffi/Application/Resource/Assets.xcassets/selectedCollapse.imageset/Contents.json
+++ b/Cheffi/Application/Resource/Assets.xcassets/selectedCollapse.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "selectedCollapse.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cheffi/Application/Resource/Assets.xcassets/selectedCollapse.imageset/selectedCollapse.svg
+++ b/Cheffi/Application/Resource/Assets.xcassets/selectedCollapse.imageset/selectedCollapse.svg
@@ -1,0 +1,14 @@
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_4901_5247)">
+<path d="M7.66667 1H1V7.66667H7.66667V1Z" stroke="black" stroke-width="1.5" stroke-linejoin="round"/>
+<path d="M17.0002 1H10.3335V7.66667H17.0002V1Z" stroke="black" stroke-width="1.5" stroke-linejoin="round"/>
+<path d="M7.66667 10.334H1V17.0007H7.66667V10.334Z" stroke="black" stroke-width="1.5" stroke-linejoin="round"/>
+<path d="M13.6668 17.0007H10.3335V10.334H17.0002V13.6673" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M16.3333 17.1667C16.7936 17.1667 17.1667 16.7936 17.1667 16.3333C17.1667 15.8731 16.7936 15.5 16.3333 15.5C15.8731 15.5 15.5 15.8731 15.5 16.3333C15.5 16.7936 15.8731 17.1667 16.3333 17.1667Z" fill="#EB4351"/>
+</g>
+<defs>
+<clipPath id="clip0_4901_5247">
+<rect width="17.5" height="17.5" fill="white" transform="translate(0.333496 0.333984)"/>
+</clipPath>
+</defs>
+</svg>

--- a/Cheffi/Application/Resource/Assets.xcassets/selectedExpand.imageset/Contents.json
+++ b/Cheffi/Application/Resource/Assets.xcassets/selectedExpand.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "selectedExpand.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cheffi/Application/Resource/Assets.xcassets/selectedExpand.imageset/selectedExpand.svg
+++ b/Cheffi/Application/Resource/Assets.xcassets/selectedExpand.imageset/selectedExpand.svg
@@ -1,0 +1,14 @@
+<svg width="16" height="17" viewBox="0 0 16 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_4901_8533)">
+<path d="M1.33325 15.334L5.33325 11.334" stroke="#0A0A0A" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M10.6667 5.33398L14.6667 1.33398" stroke="#0A0A0A" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M4.66675 16H0.666748V12" stroke="#0A0A0A" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M11.3333 0.666016H15.3333V4.66602" stroke="#0A0A0A" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M8.00008 9.33268C8.73646 9.33268 9.33341 8.73573 9.33341 7.99935C9.33341 7.26297 8.73646 6.66602 8.00008 6.66602C7.2637 6.66602 6.66675 7.26297 6.66675 7.99935C6.66675 8.73573 7.2637 9.33268 8.00008 9.33268Z" fill="#EB4351"/>
+</g>
+<defs>
+<clipPath id="clip0_4901_8533">
+<rect width="16" height="16.6667" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/Cheffi/Module/Component/Extensions/ImageExtension.swift
+++ b/Cheffi/Module/Component/Extensions/ImageExtension.swift
@@ -38,6 +38,10 @@ enum Home: String, ImageNameProtocol {
     case previousPage = "previousPage"
     case nextPage = "nextPage"
     case homeEmpty = "homeEmpty"
+    case normalCollapse = "normalCollapse"
+    case selectedCollapse = "selectedCollapse"
+    case normalExpand = "normalExpand"
+    case selectedExpand = "selectedExpand"
 }
 
 enum Review: String, ImageNameProtocol {

--- a/Cheffi/Module/Component/Models/RestResponse.swift
+++ b/Cheffi/Module/Component/Models/RestResponse.swift
@@ -12,3 +12,17 @@ struct RestResponse<T: Codable>: Codable {
     var code: Int?
     var message: String?
 }
+
+struct RestPagingResponse<T: Codable>: Codable {
+    var data: T?
+    var code: Int?
+    var message: String?
+    var hasNext: Bool?
+    
+    enum CodingKeys: String, CodingKey {
+        case data
+        case code
+        case message
+        case hasNext = "has_next"
+    }
+}

--- a/Cheffi/Module/Component/Models/ReviewModel.swift
+++ b/Cheffi/Module/Component/Models/ReviewModel.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 typealias ReviewResponse = RestResponse<[ReviewModel]>
+typealias ReviewPagingResponse = RestPagingResponse<[ReviewModel]>
 
 struct ReviewModel: Codable, Equatable {
     let id: Int

--- a/Cheffi/Module/Component/View/ReviewCell.swift
+++ b/Cheffi/Module/Component/View/ReviewCell.swift
@@ -1,5 +1,5 @@
 //
-//  PlaceCell.swift
+//  ReviewCell.swift
 //  Cheffi
 //
 //  Created by 정건호 on 6/3/24.
@@ -8,12 +8,12 @@
 import SwiftUI
 import Kingfisher
 
-struct PlaceCell: View {
+struct ReviewCell: View {
     let review: ReviewModel
-    let type: PlaceType
+    let type: ReviewType
     let screenWidth = UIWindow().screen.bounds.width
     
-    init(review: ReviewModel = .dummyData, type: PlaceType) {
+    init(review: ReviewModel = .dummyData, type: ReviewType) {
         self.review = review
         self.type = type
     }
@@ -89,12 +89,12 @@ struct PlaceCell: View {
     }
 }
 
-enum PlaceType {
+enum ReviewType {
     case small
     case medium
     case large
 }
 
 #Preview {
-    PlaceCell(type: .medium)
+    ReviewCell(type: .medium)
 }

--- a/Cheffi/Module/Feature/AllReviewView/AllReviewFeature.swift
+++ b/Cheffi/Module/Feature/AllReviewView/AllReviewFeature.swift
@@ -8,19 +8,24 @@
 import Foundation
 import ComposableArchitecture
 
-struct AllReviewFeature: Reducer {
+@Reducer
+struct AllReviewFeature {
     
+    @ObservableState
     struct State: Equatable {
-        
+        var viewType: ReviewViewType = .expand
     }
     
     enum Action: Equatable {
+        case changeViewType(type: ReviewViewType)
     }
     
     var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
-                
+            case .changeViewType(let type):
+                state.viewType = type
+                return .none
             }
         }
     }

--- a/Cheffi/Module/Feature/AllReviewView/AllReviewFeature.swift
+++ b/Cheffi/Module/Feature/AllReviewView/AllReviewFeature.swift
@@ -14,6 +14,7 @@ struct AllReviewFeature {
     @ObservableState
     struct State: Equatable {
         var viewType: ReviewViewType = .expand
+        var popularReviews: [ReviewModel]?
     }
     
     enum Action: Equatable {

--- a/Cheffi/Module/Feature/AllReviewView/AllReviewFeature.swift
+++ b/Cheffi/Module/Feature/AllReviewView/AllReviewFeature.swift
@@ -6,26 +6,53 @@
 //
 
 import Foundation
+import Combine
 import ComposableArchitecture
 
 @Reducer
 struct AllReviewFeature {
     
+    @Dependency(\.networkClient) var networkClient
+    
     @ObservableState
     struct State: Equatable {
         var viewType: ReviewViewType = .expand
+        var cursor: Int = 1
+        var hasNext: Bool = true
         var popularReviews: [ReviewModel]?
     }
     
-    enum Action: Equatable {
+    enum Action {
         case changeViewType(type: ReviewViewType)
+        case requestPopularReviews
+        case popularReviewsResponse(Result<ReviewPagingResponse, Error>)
     }
     
     var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
+                
             case .changeViewType(let type):
                 state.viewType = type
+                return .none
+                
+            case .requestPopularReviews:
+                return Effect.publisher {
+                    return networkClient
+                        .request(.popularReviews(province: "서울특별시", city: "강남구", cursor: state.cursor, size: 16))
+                        .map { Action.popularReviewsResponse(.success($0)) }
+                        .catch { Just(Action.popularReviewsResponse(.failure($0))) }
+                }
+                
+            case .popularReviewsResponse(let response):
+                switch response {
+                case .success(let result):
+                    state.cursor += 1
+                    state.hasNext = result.hasNext ?? false
+                    state.popularReviews = (state.popularReviews ?? []) + (result.data ?? [])
+                case .failure(let error):
+                    print(error)
+                }
                 return .none
             }
         }

--- a/Cheffi/Module/Feature/AllReviewView/AllReviewView.swift
+++ b/Cheffi/Module/Feature/AllReviewView/AllReviewView.swift
@@ -8,17 +8,71 @@
 import SwiftUI
 import ComposableArchitecture
 
+enum ReviewViewType {
+    case expand
+    case collapse
+}
+
 struct AllReviewView: View {
-    private let store: StoreOf<AllReviewFeature> = .init(
-        initialState: AllReviewFeature.State()) {
-            AllReviewFeature()
-        }
+    
+    @Perception.Bindable var store: StoreOf<AllReviewFeature>
+    @Environment(\.dismiss) private var dismiss
     
     var body: some View {
-        Text("전체 리뷰")
+        WithPerceptionTracking {
+            VStack(spacing: 0) {
+                NavigationBarView(type: .back)
+                    .onTapGesture {
+                        dismiss()
+                    }
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 0) {
+                        HStack(spacing: 0) {
+                            Image(name: Common.clock)
+                            Text("00 : 13 : 43")
+                                .foregroundStyle(Color.primary)
+                                .font(.suit(.bold, 18))
+                            Text("초 뒤에")
+                                .foregroundStyle(.black)
+                                .font(.suit(.bold, 18))
+                        }
+                        HStack(spacing: 4) {
+                            Text("인기 급등 맛집이 변경돼요.")
+                                .foregroundStyle(Color.black)
+                                .font(.suit(.regular, 18))
+                            Image(name: Common.info)
+                            Spacer()
+                            HStack(spacing: 20) {
+                                Image(name: store.viewType == .expand ? Home.selectedExpand : Home.normalExpand)
+                                    .onTapGesture {
+                                        store.send(.changeViewType(type: .expand))
+                                    }
+                                Image(name: store.viewType == .collapse ? Home.selectedCollapse : Home.normalCollapse)
+                                    .onTapGesture {
+                                        store.send(.changeViewType(type: .collapse))
+                                    }
+                            }
+                        }
+                        
+                    }
+                    
+                    
+                    // Cell
+                    PlaceCell(type: .large)
+                        .padding(.top, 24)
+                }
+                .padding(.top, 32)
+                .padding(.horizontal, 16)
+            }
+            .toolbar(.hidden, for: .navigationBar)
+        }
     }
 }
 
+
 #Preview {
-    AllReviewView()
+    AllReviewView(store: .init(
+        initialState: AllReviewFeature.State()) {
+            AllReviewFeature()
+        })
 }

--- a/Cheffi/Module/Feature/AllReviewView/AllReviewView.swift
+++ b/Cheffi/Module/Feature/AllReviewView/AllReviewView.swift
@@ -66,12 +66,19 @@ struct AllReviewView: View {
                     Group {
                         if let popularReviews = store.popularReviews {
                             if store.viewType == .expand {
-                                ForEach(0..<popularReviews.count, id: \.self) { index in
-                                    WithPerceptionTracking {
-                                        PlaceCell(
-                                            review: popularReviews[index],
-                                            type: .large
-                                        )
+                                LazyVStack {
+                                    ForEach(0..<popularReviews.count, id: \.self) { index in
+                                        WithPerceptionTracking {
+                                            PlaceCell(
+                                                review: popularReviews[index],
+                                                type: .large
+                                            )
+                                            .onAppear {
+                                                if popularReviews.count - 3 == index, store.hasNext {
+                                                    store.send(.requestPopularReviews)
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                             } else {
@@ -82,6 +89,11 @@ struct AllReviewView: View {
                                                 review: popularReviews[index],
                                                 type: .small
                                             )
+                                            .onAppear {
+                                                if popularReviews.count - 3 == index, store.hasNext {
+                                                    store.send(.requestPopularReviews)
+                                                }
+                                            }
                                         }
                                     }
                                 }

--- a/Cheffi/Module/Feature/AllReviewView/AllReviewView.swift
+++ b/Cheffi/Module/Feature/AllReviewView/AllReviewView.swift
@@ -69,7 +69,7 @@ struct AllReviewView: View {
                                 LazyVStack {
                                     ForEach(0..<popularReviews.count, id: \.self) { index in
                                         WithPerceptionTracking {
-                                            PlaceCell(
+                                            ReviewCell(
                                                 review: popularReviews[index],
                                                 type: .large
                                             )
@@ -85,7 +85,7 @@ struct AllReviewView: View {
                                 LazyVGrid(columns: columns) {
                                     ForEach(0..<popularReviews.count, id: \.self) { index in
                                         WithPerceptionTracking {
-                                            PlaceCell(
+                                            ReviewCell(
                                                 review: popularReviews[index],
                                                 type: .small
                                             )

--- a/Cheffi/Module/Feature/AllReviewView/AllReviewView.swift
+++ b/Cheffi/Module/Feature/AllReviewView/AllReviewView.swift
@@ -18,6 +18,11 @@ struct AllReviewView: View {
     @Perception.Bindable var store: StoreOf<AllReviewFeature>
     @Environment(\.dismiss) private var dismiss
     
+    private let columns = [
+        GridItem(.flexible(), alignment: .top),
+        GridItem(.flexible(), alignment: .top)
+    ]
+    
     var body: some View {
         WithPerceptionTracking {
             VStack(spacing: 0) {
@@ -55,20 +60,42 @@ struct AllReviewView: View {
                         }
                         
                     }
+                    .padding(.horizontal, 16)
+                    .padding(.top, 32)
                     
-                    
-                    // Cell
-                    PlaceCell(type: .large)
-                        .padding(.top, 24)
+                    Group {
+                        if let popularReviews = store.popularReviews {
+                            if store.viewType == .expand {
+                                ForEach(0..<popularReviews.count, id: \.self) { index in
+                                    WithPerceptionTracking {
+                                        PlaceCell(
+                                            review: popularReviews[index],
+                                            type: .large
+                                        )
+                                    }
+                                }
+                            } else {
+                                LazyVGrid(columns: columns) {
+                                    ForEach(0..<popularReviews.count, id: \.self) { index in
+                                        WithPerceptionTracking {
+                                            PlaceCell(
+                                                review: popularReviews[index],
+                                                type: .small
+                                            )
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    .padding(.top, 24)
+                    .padding(.horizontal, 16)
                 }
-                .padding(.top, 32)
-                .padding(.horizontal, 16)
             }
             .toolbar(.hidden, for: .navigationBar)
         }
     }
 }
-
 
 #Preview {
     AllReviewView(store: .init(

--- a/Cheffi/Module/Feature/Home/CheffiPlace/HomeCheffiPlaceView.swift
+++ b/Cheffi/Module/Feature/Home/CheffiPlace/HomeCheffiPlaceView.swift
@@ -36,7 +36,7 @@ struct HomeCheffiPlaceView: View {
                                         ScrollView(showsIndicators: false) {
                                             LazyVGrid(columns: columns, spacing: 24) {
                                                 ForEach(reviews, id: \.id) { review in
-                                                    PlaceCell(review: review, type: .small)
+                                                    ReviewCell(review: review, type: .small)
                                                 }
                                             }
                                             .padding(.horizontal, 16)

--- a/Cheffi/Module/Feature/Home/HomeView.swift
+++ b/Cheffi/Module/Feature/Home/HomeView.swift
@@ -11,7 +11,7 @@ import ComposableArchitecture
 struct HomeView: View {
     var body: some View {
         VStack {
-            NavigationBarView()
+            NavigationBarView(type: .normal)
             ScrollView(showsIndicators: false) {
                 // 인기 급등 맛집
                 HomePopularView()

--- a/Cheffi/Module/Feature/Home/NavigationBar/NavigationBarView.swift
+++ b/Cheffi/Module/Feature/Home/NavigationBar/NavigationBarView.swift
@@ -8,45 +8,73 @@
 import SwiftUI
 import ComposableArchitecture
 
+enum HomeNavigationType {
+    case normal
+    case back
+}
+
 struct NavigationBarView: View {
     
     @Perception.Bindable var store: StoreOf<NavigationBarFeature> = .init(
         initialState: NavigationBarFeature.State()) {
             NavigationBarFeature()
         }
+    let type: HomeNavigationType
     
     var body: some View {
         WithPerceptionTracking {
             HStack(spacing: 0) {
-                HStack(spacing: 8) {
-                    Text("서울특별시 성동구")
-                        .padding(.vertical, 6)
-                        .padding(.horizontal, 12)
-                        .background(.black)
-                        .foregroundStyle(.white)
-                        .font(.suit(.medium, 16))
-                        .clipShape(.rect(cornerRadius: 20))
-                    Image(name: Common.rightArrow)
-                        .padding(3)
-                        .background(.black)
-                        .clipShape(.rect(cornerRadius: 16))
+                if type == .back {
+                    HStack {
+                        Image(name: Common.leftArrow)
+                            .resizable()
+                            .renderingMode(.template)
+                            .frame(width: 24, height: 24)
+                            .padding(.leading, 10)
+                        Spacer()
+                    }
+                    Spacer()
                 }
-                .onTapGesture {
-                    store.send(.regionTapped)
-                }
+                regionButton()
                 Spacer()
-                Image(name: Home.search)
-                    .padding(10)
-                    .onTapGesture {
-                        store.send(.searchTapped)
-                    }
-                Image(name: Home.alarm)
-                    .padding(10)
-                    .onTapGesture {
-                        store.send(.alarmTapped)
-                    }
+                HStack(spacing: 0) {
+                    Spacer()
+                    Image(name: Home.search)
+                        .padding(.trailing, 20)
+                        .onTapGesture {
+                            store.send(.searchTapped)
+                        }
+                    Image(name: Home.alarm)
+                        .padding(.trailing, 10)
+                        .onTapGesture {
+                            store.send(.alarmTapped)
+                        }
+                }
             }
             .padding(.horizontal, 16)
+        }
+    }
+    
+    @ViewBuilder
+    private func regionButton() -> some View {
+        HStack(spacing: 8) {
+            Text("서울특별시 성동구")
+                .padding(.vertical, 6)
+                .padding(.horizontal, 12)
+                .background(.black)
+                .foregroundStyle(.white)
+                .font(.suit(.medium, 16))
+                .clipShape(.rect(cornerRadius: 20))
+            if type == .normal {
+                Image(name: Common.rightArrow)
+                    .padding(3)
+                    .background(.black)
+                    .clipShape(.rect(cornerRadius: 16))
+            }
+        }
+        .layoutPriority(1)
+        .onTapGesture {
+            store.send(.regionTapped)
         }
     }
 }

--- a/Cheffi/Module/Feature/Home/NavigationBar/NavigationBarView.swift
+++ b/Cheffi/Module/Feature/Home/NavigationBar/NavigationBarView.swift
@@ -33,7 +33,6 @@ struct NavigationBarView: View {
                             .padding(.leading, 10)
                         Spacer()
                     }
-                    Spacer()
                 }
                 regionButton()
                 Spacer()
@@ -52,6 +51,7 @@ struct NavigationBarView: View {
                 }
             }
             .padding(.horizontal, 16)
+            .frame(height: 44)
         }
     }
     

--- a/Cheffi/Module/Feature/Home/Popular/HomePopularFeature.swift
+++ b/Cheffi/Module/Feature/Home/Popular/HomePopularFeature.swift
@@ -71,7 +71,7 @@ extension HomePopularFeature {
         @ObservableState
         enum State: Equatable {
             case moveToReviewDetailView(ReviewDetailFeature.State)
-            case moveToAllReviewView(AllReviewFeature.State = .init())
+            case moveToAllReviewView(AllReviewFeature.State)
         }
         
         enum Action {

--- a/Cheffi/Module/Feature/Home/Popular/HomePopularView.swift
+++ b/Cheffi/Module/Feature/Home/Popular/HomePopularView.swift
@@ -68,7 +68,9 @@ struct HomePopularView: View {
                                         store.send(.toolTipTapped)
                                     }
                                 Spacer()
-                                NavigationLink(state: HomePopularFeature.Path.State.moveToAllReviewView()) {
+                                NavigationLink(state: HomePopularFeature.Path.State.moveToAllReviewView(
+                                    .init(popularReviews: store.popularReviews)
+                                )) {
                                     HStack {
                                         Text("전체보기")
                                             .foregroundStyle(Color.grey6)
@@ -172,8 +174,8 @@ struct HomePopularView: View {
                         ReviewDetailView(store: store)
                     }
                 case .moveToAllReviewView:
-                    if let _ = store.scope(state: \.moveToAllReviewView, action: \.moveToAllReviewView) {
-                        AllReviewView()
+                    if let store = store.scope(state: \.moveToAllReviewView, action: \.moveToAllReviewView) {
+                        AllReviewView(store: store)
                     }
                 }
             }

--- a/Cheffi/Module/Feature/Home/Popular/HomePopularView.swift
+++ b/Cheffi/Module/Feature/Home/Popular/HomePopularView.swift
@@ -95,21 +95,21 @@ struct HomePopularView: View {
                                             NavigationLink(
                                                 state: HomePopularFeature.Path.State.moveToReviewDetailView(.init(id: store.popularReviews[0].id))
                                             ) {
-                                                PlaceCell(review: store.popularReviews[0], type: .medium)
+                                                ReviewCell(review: store.popularReviews[0], type: .medium)
                                             }
                                             LazyVGrid(columns: columns) {
                                                 if store.popularReviews.count-1 >= 1 {
                                                     NavigationLink(
                                                         state: HomePopularFeature.Path.State.moveToReviewDetailView(.init(id: store.popularReviews[1].id))
                                                     ) {
-                                                        PlaceCell(review: store.popularReviews[1], type: .small)
+                                                        ReviewCell(review: store.popularReviews[1], type: .small)
                                                     }
                                                 }
                                                 if store.popularReviews.count-1 >= 2 {
                                                     NavigationLink(
                                                         state: HomePopularFeature.Path.State.moveToReviewDetailView(.init(id: store.popularReviews[2].id))
                                                     ) {
-                                                        PlaceCell(review: store.popularReviews[2], type: .small)
+                                                        ReviewCell(review: store.popularReviews[2], type: .small)
                                                     }
                                                 }
                                             }
@@ -121,7 +121,7 @@ struct HomePopularView: View {
                                                         NavigationLink(
                                                             state: HomePopularFeature.Path.State.moveToReviewDetailView(.init(id: store.popularReviews[reviewIndex].id))
                                                         ) {
-                                                            PlaceCell(review: store.popularReviews[reviewIndex], type: .small)
+                                                            ReviewCell(review: store.popularReviews[reviewIndex], type: .small)
                                                         }
                                                     }
                                                 }

--- a/Cheffi/Module/Feature/Review/ReviewDetailView.swift
+++ b/Cheffi/Module/Feature/Review/ReviewDetailView.swift
@@ -269,7 +269,7 @@ struct ReviewDetailView: View {
                             .padding(.horizontal, 16)
                         }
                         .edgesIgnoringSafeArea(.top)
-                        .navigationBarHidden(true)
+                        .toolbar(.hidden, for: .navigationBar)
                         .toast(
                             message: "주소가 클립보드에 복사되었습니다.",
                             type: .check,
@@ -278,7 +278,7 @@ struct ReviewDetailView: View {
                     }
                 } else {
                     ProgressView()
-                        .navigationBarHidden(true)
+                        .toolbar(.hidden, for: .navigationBar)
                 }
             }
             .onAppear {


### PR DESCRIPTION
## 🌁 Background
- 

## 📱 Screenshot
![Simulator Screen Recording - iPhone 15 - 2024-07-11 at 20 44 16](https://github.com/Cheffi-GitHub/Cheffi-iOS/assets/60253668/e9830e90-d6b3-4ec0-a194-32bc97b52c73)


## 👩‍💻 Contents
- 인기 급등 맛집 전체보기 화면 구현

RestResponse.swift
페이징에 필요한 response값을 사용하기 위해서 RestPagingResponse를 RestResponse.swift내에 구현했습니다.

AllReviewView.swift
LazyVStack, LazyVGrid를 사용하여 사용자가 스크롤을 할 때,
화면에 보여지는 뷰의 index를 이용하여 적당히 내리게 되면(현재는 마지막 index - 3) 
다음 페이지가 있을 경우에 api를 호출하는 방식으로 구현했습니다.


## ✅ Testing
- 


## 📝 Review Note
- 피그마에는 스켈레톤 뷰가 있지만, 홈 화면에서 api를 통해 받아놓은 인기 급등 맛집 정보를
전체보기 화면으로 이동 시 그대로 가져와서 즉시 표기하고, 
모아보기 펼쳐보기를 눌러도 정보는 그대로고 뷰의 표시 방법만 달라지기 때문에 
사용자가 데이터를 불러오는 것에 대해서 기다릴 필요가 없습니다.
따라서, 스켈레톤 뷰의 필요성에 대해서 다음 회의 때 이야기 나눠보면 좋을 것 같습니다!


## 📣 Related Issue
-