### PR TITLE
[FEAT] GET/ Path variable 방식의 API Request 추가 구현

### DIFF
--- a/Cheffi.xcodeproj/project.pbxproj
+++ b/Cheffi.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		A61FC3CF2C3D68E200C732C6 /* DataRequest+Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = A61FC3CE2C3D68E200C732C6 /* DataRequest+Response.swift */; };
 		A61FC3D22C3D849700C732C6 /* AnyCodable in Frameworks */ = {isa = PBXBuildFile; productRef = A61FC3D12C3D849700C732C6 /* AnyCodable */; };
 		A62EEAD92C2D9BA000926242 /* LaunchScreenFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = A62EEAD82C2D9BA000926242 /* LaunchScreenFeature.swift */; };
+		A670024E2C5CA61E00B7F336 /* URLParameterEncoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = A670024D2C5CA61E00B7F336 /* URLParameterEncoding.swift */; };
 		A67677F32C1738EF0089A269 /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = A67677F22C1738EF0089A269 /* AppEnvironment.swift */; };
 		A678A4852C2C5F0800A3D16B /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A678A4842C2C5F0800A3D16B /* Launch Screen.storyboard */; };
 		A678A4882C2C632F00A3D16B /* LaunchScreenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A678A4872C2C632F00A3D16B /* LaunchScreenView.swift */; };
@@ -76,6 +77,7 @@
 		A688B0B02C29B6A800E4E3A2 /* Authority.swift in Sources */ = {isa = PBXBuildFile; fileRef = A688B0AF2C29B6A800E4E3A2 /* Authority.swift */; };
 		A69989FC2C47FF8700850EE7 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A69989FB2C47FF8700850EE7 /* RootView.swift */; };
 		A69989FE2C47FF8D00850EE7 /* RootFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = A69989FD2C47FF8D00850EE7 /* RootFeature.swift */; };
+		A6DC44182C5C98E200423B90 /* OtherProfileModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6DC44172C5C98E200423B90 /* OtherProfileModel.swift */; };
 		A6F5E6C82C1B21630053C2E8 /* NetworkRequestInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6F5E6C72C1B21630053C2E8 /* NetworkRequestInterceptor.swift */; };
 		A6F5E6CC2C1B22C00053C2E8 /* NetworkEventLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6F5E6CB2C1B22C00053C2E8 /* NetworkEventLogger.swift */; };
 		A6F5E6CE2C1B2BA80053C2E8 /* DataExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6F5E6CD2C1B2BA80053C2E8 /* DataExtension.swift */; };
@@ -172,6 +174,7 @@
 		A61FC3CC2C3D68D900C732C6 /* CheffiError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheffiError.swift; sourceTree = "<group>"; };
 		A61FC3CE2C3D68E200C732C6 /* DataRequest+Response.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DataRequest+Response.swift"; sourceTree = "<group>"; };
 		A62EEAD82C2D9BA000926242 /* LaunchScreenFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchScreenFeature.swift; sourceTree = "<group>"; };
+		A670024D2C5CA61E00B7F336 /* URLParameterEncoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLParameterEncoding.swift; sourceTree = "<group>"; };
 		A67677E92C1730C60089A269 /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		A67677F22C1738EF0089A269 /* AppEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEnvironment.swift; sourceTree = "<group>"; };
 		A67677F62C1740230089A269 /* Secrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
@@ -184,6 +187,7 @@
 		A688B0AF2C29B6A800E4E3A2 /* Authority.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Authority.swift; sourceTree = "<group>"; };
 		A69989FB2C47FF8700850EE7 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		A69989FD2C47FF8D00850EE7 /* RootFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootFeature.swift; sourceTree = "<group>"; };
+		A6DC44172C5C98E200423B90 /* OtherProfileModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OtherProfileModel.swift; sourceTree = "<group>"; };
 		A6F5E6C72C1B21630053C2E8 /* NetworkRequestInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkRequestInterceptor.swift; sourceTree = "<group>"; };
 		A6F5E6CB2C1B22C00053C2E8 /* NetworkEventLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkEventLogger.swift; sourceTree = "<group>"; };
 		A6F5E6CD2C1B2BA80053C2E8 /* DataExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataExtension.swift; sourceTree = "<group>"; };
@@ -508,6 +512,7 @@
 			isa = PBXGroup;
 			children = (
 				A61FC3CC2C3D68D900C732C6 /* CheffiError.swift */,
+				A670024D2C5CA61E00B7F336 /* URLParameterEncoding.swift */,
 				A61FC3CE2C3D68E200C732C6 /* DataRequest+Response.swift */,
 			);
 			path = Component;
@@ -539,6 +544,7 @@
 				A61FC3C92C3D689200C732C6 /* RestErrorResponse.swift */,
 				A688B0AC2C29B68E00E4E3A2 /* LoginKakaoModel.swift */,
 				54F217AA2C2D2F1B00892DBD /* ReviewModel.swift */,
+				A6DC44172C5C98E200423B90 /* OtherProfileModel.swift */,
 				54E285F92C2FE28700AD7939 /* TagsModel.swift */,
 				5419304C2C3D798A0080CA57 /* ReviewDetailModel.swift */,
 				A688B0AE2C29B69600E4E3A2 /* Objects */,
@@ -782,8 +788,10 @@
 				A6F5E6FE2C284D350053C2E8 /* TokenStorageEventMonitor.swift in Sources */,
 				A61FC3CF2C3D68E200C732C6 /* DataRequest+Response.swift in Sources */,
 				549B1F8F2C0607C7005C9432 /* CheffiApp.swift in Sources */,
+				A6DC44182C5C98E200423B90 /* OtherProfileModel.swift in Sources */,
 				540BE9B42C231036009180AE /* WriterRow.swift in Sources */,
 				54073B882C0D913800597973 /* NavigationBarFeature.swift in Sources */,
+				A670024E2C5CA61E00B7F336 /* URLParameterEncoding.swift in Sources */,
 				5419304B2C3D497D0080CA57 /* AllReviewFeature.swift in Sources */,
 				543F0AE42C10263100DFBDB1 /* HomeCheffiStoryView.swift in Sources */,
 				547B4BC92C4566F300C4B1B4 /* MainTabFeature.swift in Sources */,

--- a/Cheffi/Module/Component/Models/OtherProfileModel.swift
+++ b/Cheffi/Module/Component/Models/OtherProfileModel.swift
@@ -1,0 +1,40 @@
+//
+//  OtherProfileModel.swift
+//  Cheffi
+//
+//  Created by 이서준 on 8/2/24.
+//
+
+import Foundation
+
+typealias OtherProfileResponse = RestResponse<OtherProfileModel>
+
+struct OtherProfileModel: Codable {
+    let id: Int
+    let nickname: String
+    let introduction: String?
+    let followerCount: Int
+    let followingCount: Int
+    let post: Int
+    let cheffiCoin: Int
+    let point: Int
+    let photo: PhotoInfo
+    let following: Bool?
+    let blocking: Bool?
+    let tags: [TagsModel]?
+    
+    enum CodingKeys: String, CodingKey {
+        case id
+        case nickname
+        case introduction
+        case followerCount = "follower_count"
+        case followingCount = "following_count"
+        case post
+        case cheffiCoin = "cheffi_coin"
+        case point
+        case photo
+        case following
+        case blocking
+        case tags
+    }
+}

--- a/Cheffi/Network/Component/URLParameterEncoding.swift
+++ b/Cheffi/Network/Component/URLParameterEncoding.swift
@@ -1,0 +1,18 @@
+//
+//  URLParameterEncoding.swift
+//  Cheffi
+//
+//  Created by 이서준 on 8/2/24.
+//
+
+import Foundation
+import Alamofire
+
+typealias HTTPOptions = (method: HTTPMethod, encodingType: URLParameterEncoding)
+
+enum URLParameterEncoding {
+    case path
+    case query
+    case pathQuery
+    case body
+}

--- a/Cheffi/Network/EndPoint/RestRouter+EndPoint.swift
+++ b/Cheffi/Network/EndPoint/RestRouter+EndPoint.swift
@@ -40,11 +40,11 @@ extension RestRouter: EndPoint {
         return parameters
     }
     
-    var method: HTTPMethod {
+    var options: HTTPOptions {
         switch self {
         case .oauthLoginKakao,
              .testUpload:
-            return .post
+            return (.post, .body)
             
         case .avatarsNickname,
              .popularReviews,
@@ -53,7 +53,10 @@ extension RestRouter: EndPoint {
              .tags,
              .testSessionIssue,
              .testAuth:
-            return .get
+            return (.get, .query)
+            
+        case .profile:
+            return (.get, .path)
         }
     }
 }

--- a/Cheffi/Network/EndPoint/RestRouter+Path.swift
+++ b/Cheffi/Network/EndPoint/RestRouter+Path.swift
@@ -20,6 +20,8 @@ extension RestRouter {
             return "/api/v1/reviews/areas/tags"
         case .reviewDetail:
             return "/api/v1/reviews"
+        case .profile(let id):
+            return "/api/v1/profile/\(id)"
         case .tags:
             return "/api/v1/tags"
         case .testUpload:

--- a/Cheffi/Network/EndPoint/RestRouter.swift
+++ b/Cheffi/Network/EndPoint/RestRouter.swift
@@ -22,6 +22,7 @@ enum RestRouter {
     // - MARK: 04. 검색페이지
     
     // - MARK: 05. 프로필 조회
+    case profile(id: String)
     
     // - MARK: 06. 리뷰 상세 페이지
     

--- a/Cheffi/Network/EndPoint/RestRouter.swift
+++ b/Cheffi/Network/EndPoint/RestRouter.swift
@@ -8,26 +8,54 @@
 import Foundation
 
 enum RestRouter {
-    // - MARK: OAuth
-    // 소셜 로그인 API { 카카오톡 }
+    // - MARK: 01. 로그인
     case oauthLoginKakao(token: String, platform: String)
     
-    // - MARK: 회원가입
+    // - MARK: 02. 회원가입
     case avatarsNickname(nickName: String)
     
-    // - MARK: 홈
+    // - MARK: 03. 메인페이지
     case popularReviews(province: String, city: String, cursor: Int, size: Int)
     case cheffiPlace(province: String, city: String, cursor: Int, size: Int, tag_id: Int)
     case reviewDetail(id: Int)
     
-    // - MARK: 태그
+    // - MARK: 04. 검색페이지
+    
+    // - MARK: 05. 프로필 조회
+    
+    // - MARK: 06. 리뷰 상세 페이지
+    
+    // - MARK: 07. 리뷰 등록, 수정, 삭제
+    
+    // - MARK: 08. 프로필 수정
+    
+    // - MARK: 09. 팔로우
+    
+    // - MARK: 10. 태그
     case tags(type: String)
     
-    // - MARK: Test
-    // 이미지 업로드 테스트 API
+    // - MARK: 11. 알림
+    
+    // - MARK: 12. 쉐피코인 및 포인트
+    
+    // - MARK: 13. 찜(북마크)
+    
+    // - MARK: 14. 지역구 조회
+    
+    // - MARK: 15. 신고
+    
+    // - MARK: 16. 차단
+    
+    // - MARK: 17. 자주 묻는 질문
+    
+    // - MARK: 18. 공지사항
+    
+    // - MARK: 19. 아바타
+    
+    // - MARK: 20. 리뷰
+    
+    // - MARK: ETC. 테스트
     case testUpload
-    // 테스트용 세션 발급 API
     case testSessionIssue
-    // 세션 토큰 테스트 API
     case testAuth
 }


### PR DESCRIPTION
## 🌁 Background
1. 이전 네트워크 모듈은 Parameter로 입력된 데이터가 URL QueryString으로만 인코딩 가능한 한계가 있음(= Path variable 방식의 API를 요청해야하는 경우가 고려되어 있지 않음)


## 👩‍💻 Contents

1. URLParameterEncoding.swift
다양한 방식을 고려해보면서, 현재 구조에서 Path 방식만 추가되는 형태의 확장은 같은 문제 배경(Background)를 반복하게 될것 같다는 결론
=> Path, Query, Path+Query, Body(POST...) 같은 다양한 조건을 생성하여 추후 확장성에 대한 대비를 진행하였습니다.

```swift
enum URLParameterEncoding {
    case path // Parameter가 이미 path에 포함되어 추가적인 인코딩이 필요하지 않은 Case
    case query // Parameter가 URL QueryString으로 인코딩되어 추가되어야 하는 Case
    case pathQuery // path와 query 방식이 한 번에 모두 사용되는 case(현재 Cheffi API에는 없는 종류)
    case body // Parameter가 EndPoint Body(본문)에 인코딩되어 추가되어야 하는 Case
}
```

2. EndPoint 구조 일부 변경
HTTPOptions을 추가하여, HTTPMethod 종류와 함께 Encoding 방식을 같이 열거해놓는 구로조 변경했습니다.

```swift
typealias HTTPOptions = (method: HTTPMethod, encodingType: URLParameterEncoding)

//현재
var options: HTTPOptions { get }

//이전
//var method: HTTPMethod { get }
```

```swift
var options: HTTPOptions {
    switch self {
    case .oauthLoginKakao,
         .testUpload:
        return (.post, .body)
        
    case .avatarsNickname,
         .popularReviews,
         .cheffiPlace,
         .reviewDetail,
         .tags,
         .testSessionIssue,
         .testAuth:
        return (.get, .query)
        
    case .profile:
        return (.get, .path)
    }
}
```

## 📝 Review Note
#### 의도(사용방법)

1. Path Variable 방식의 API는 path를 구현할때부터 String 값에 포함시켜 구현합니다.
```swift
var path: String {
    switch self {
    case .profile(let id):
        return "/api/v1/profile/\(id)"
    }
}
```

2. options 프로퍼티의 switch self 열거형에서 API Method 방식과 함께 URLParameterEncoding 방식을 지정합니다.

