### PR TITLE
[REFACTOR] Path, Query Parameter를 한 번에 사용하는 API 요청 시나리오 고려

### DIFF
--- a/Cheffi/Network/EndPoint/EndPoint.swift
+++ b/Cheffi/Network/EndPoint/EndPoint.swift
@@ -12,12 +12,17 @@ protocol EndPoint: URLRequestConvertible {
     var baseURL: String { get }
     var path: String { get }
     var headers: HTTPHeaders { get }
-    var parameters: Parameters { get }
+    var pathParameters: Parameters { get }
+    var queryParameters: Parameters { get }
     var options: HTTPOptions { get }
 }
 
 extension EndPoint {
     func asURLRequest() throws -> URLRequest {
+        let path = pathParameters.reduce(path) { path, parameter in
+            path.replacingOccurrences(of: "{\(parameter.key)}", with: "\(parameter.value)")
+        }
+        
         guard let url = URL(string: baseURL.appending(path)) else {
             throw AFError.createURLRequestFailed(error: URLError(.badURL))
         }
@@ -28,16 +33,16 @@ extension EndPoint {
         return try encodeParameters(urlRequest)
     }
     
-    private func encodeParameters(_ request: URLRequest) throws -> URLRequest {
+    func encodeParameters(_ request: URLRequest) throws -> URLRequest {
         switch options.encodingType {
         case .path:
             return request
             
         case .query, .pathQuery:
-            return try URLEncoding.queryString.encode(request, with: parameters)
+            return try URLEncoding.queryString.encode(request, with: queryParameters)
             
         case .body:
-            return try JSONEncoding.prettyPrinted.encode(request, with: parameters)
+            return try JSONEncoding.prettyPrinted.encode(request, with: queryParameters)
         }
     }
 }

--- a/Cheffi/Network/EndPoint/RestRouter+Path.swift
+++ b/Cheffi/Network/EndPoint/RestRouter+Path.swift
@@ -20,8 +20,10 @@ extension RestRouter {
             return "/api/v1/reviews/areas/tags"
         case .reviewDetail:
             return "/api/v1/reviews"
-        case .profile(let id):
-            return "/api/v1/profile/\(id)"
+        case .profile:
+            return "/api/v1/profile/{id}"
+        case .profileReviews:
+            return "/api/v1/profile/{id}/reviews"
         case .tags:
             return "/api/v1/tags"
         case .testUpload:

--- a/Cheffi/Network/EndPoint/RestRouter.swift
+++ b/Cheffi/Network/EndPoint/RestRouter.swift
@@ -23,6 +23,7 @@ enum RestRouter {
     
     // - MARK: 05. 프로필 조회
     case profile(id: String)
+    case profileReviews(id: String, size: Int)
     
     // - MARK: 06. 리뷰 상세 페이지
     


### PR DESCRIPTION
## 🌁 Background
1. Path Parameter와 Query Parameter가 API 요청을 위해 모두 필요한 경우, Path에 추가된 Parameter가 Query Parameter로 다시 한번 추가되는 문제


## 👩‍💻 Contents

1. Path와 Query Parameter의 명시적인 구분 및 활용을 위한 Parameter 분리(=세분화)
```swift
// Before
var parameters: Parameters { get }

// After
var pathParameters: Parameters { get }
var queryParameters: Parameters { get }
```

2. RestRouter+Path.swift
Path Parameter의 추가가 필요한 API의 경우 "{key 이름}"을 포함하여 Path String 작성
```swift
// Before
case .profile:
      return "/api/v1/profile/{id}"
case .profileReviews:
    return "/api/v1/profile/{id}/reviews"
```

3. EndPoint.swift
```swift
func asURLRequest() throws -> URLRequest {
    // Path Parameter인 경우: Path String의 {parameter.key} => parameter.value로 변환
    let path = pathParameters.reduce(path) { path, parameter in
        path.replacingOccurrences(of: "{\(parameter.key)}", with: "\(parameter.value)")
    }
    
    guard let url = URL(string: baseURL.appending(path)) else {
        throw AFError.createURLRequestFailed(error: URLError(.badURL))
    }

    var urlRequest = try URLRequest(url: url, method: options.method)
    urlRequest.headers = headers
    
    return try encodeParameters(urlRequest)
}
```

```swift
var queryParameters: Parameters {
    // Query Parameter인 경우: Path Parameter를 제외한 파라미터만 Query Parameter로 추가
    return extractParameters { !path.contains("{\($0)}") }
}
```

## 📝 Review Note
#### 의도(사용방법)

1. Path Variable 방식의 API는 path를 구현할때부터 String 값에 "{key 이름}" 포함시켜 구현합니다.
```swift
case profileReviews(id: String, size: Int)

var path: String {
    switch self {
    case .profileReviews:
        return "/api/v1/profile/{id}/reviews"
    }
}
```
