### PR TITLE
[REFACTOR] 홈 화면 뷰 리팩토링

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,4 @@ iOSInjectionProject/
 Secrets.xcconfig
 
 # End of https://www.toptal.com/developers/gitignore/api/xcode,swift,cocoapods
+.DS_Store

--- a/Cheffi.xcodeproj/project.pbxproj
+++ b/Cheffi.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		54F217AB2C2D2F1B00892DBD /* ReviewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F217AA2C2D2F1B00892DBD /* ReviewModel.swift */; };
 		54F217AD2C2D2FDB00892DBD /* Photo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F217AC2C2D2FDB00892DBD /* Photo.swift */; };
 		54F217B22C2D685400892DBD /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 54F217B12C2D685400892DBD /* Kingfisher */; };
+		6040AAF52CA275FA0016338E /* LineHeightModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6040AAF42CA275F30016338E /* LineHeightModifier.swift */; };
 		A611D9D12C187D6500ABF38C /* EndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = A611D9D02C187D6500ABF38C /* EndPoint.swift */; };
 		A611D9D32C187D7800ABF38C /* RestRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A611D9D22C187D7800ABF38C /* RestRouter.swift */; };
 		A611D9D52C187D8400ABF38C /* NetworkClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A611D9D42C187D8400ABF38C /* NetworkClient.swift */; };
@@ -170,6 +171,7 @@
 		54F217A82C2BC42A00892DBD /* ScrollViewOffset.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScrollViewOffset.swift; sourceTree = "<group>"; };
 		54F217AA2C2D2F1B00892DBD /* ReviewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewModel.swift; sourceTree = "<group>"; };
 		54F217AC2C2D2FDB00892DBD /* Photo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Photo.swift; sourceTree = "<group>"; };
+		6040AAF42CA275F30016338E /* LineHeightModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineHeightModifier.swift; sourceTree = "<group>"; };
 		A611D9D02C187D6500ABF38C /* EndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndPoint.swift; sourceTree = "<group>"; };
 		A611D9D22C187D7800ABF38C /* RestRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestRouter.swift; sourceTree = "<group>"; };
 		A611D9D42C187D8400ABF38C /* NetworkClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkClient.swift; sourceTree = "<group>"; };
@@ -362,6 +364,7 @@
 		548BC0632C086AE300A73F66 /* Util */ = {
 			isa = PBXGroup;
 			children = (
+				6040AAF42CA275F30016338E /* LineHeightModifier.swift */,
 				54C30E302C47EDDE00DA6FF8 /* FirstAppearModifer.swift */,
 				54F217A82C2BC42A00892DBD /* ScrollViewOffset.swift */,
 				A6F5E6FF2C284E400053C2E8 /* KeychainManager.swift */,
@@ -851,6 +854,7 @@
 				54073B8A2C0D932D00597973 /* HomePopularView.swift in Sources */,
 				A688B0AD2C29B68E00E4E3A2 /* LoginKakaoModel.swift in Sources */,
 				A6F5E6CE2C1B2BA80053C2E8 /* DataExtension.swift in Sources */,
+				6040AAF52CA275FA0016338E /* LineHeightModifier.swift in Sources */,
 				A61FC3CA2C3D689200C732C6 /* RestErrorResponse.swift in Sources */,
 				54C30E312C47EDDE00DA6FF8 /* FirstAppearModifer.swift in Sources */,
 				A67677F32C1738EF0089A269 /* AppEnvironment.swift in Sources */,

--- a/Cheffi.xcodeproj/project.pbxproj
+++ b/Cheffi.xcodeproj/project.pbxproj
@@ -11,8 +11,8 @@
 		54073B7D2C0C564700597973 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54073B7C2C0C564700597973 /* HomeView.swift */; };
 		54073B802C0CBC6500597973 /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = 54073B7F2C0CBC6500597973 /* ComposableArchitecture */; };
 		54073B832C0D906300597973 /* HomePopularFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54073B822C0D906300597973 /* HomePopularFeature.swift */; };
-		54073B852C0D908200597973 /* NavigationBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54073B842C0D908200597973 /* NavigationBarView.swift */; };
-		54073B882C0D913800597973 /* NavigationBarFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54073B872C0D913800597973 /* NavigationBarFeature.swift */; };
+		54073B852C0D908200597973 /* HomeNavigationBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54073B842C0D908200597973 /* HomeNavigationBarView.swift */; };
+		54073B882C0D913800597973 /* HomeNavigationBarFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54073B872C0D913800597973 /* HomeNavigationBarFeature.swift */; };
 		54073B8A2C0D932D00597973 /* HomePopularView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54073B892C0D932D00597973 /* HomePopularView.swift */; };
 		54073B8C2C0D98E500597973 /* ReviewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54073B8B2C0D98E400597973 /* ReviewCell.swift */; };
 		540BE9B02C22C607009180AE /* ReviewDetailFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 540BE9AF2C22C607009180AE /* ReviewDetailFeature.swift */; };
@@ -121,8 +121,8 @@
 		54073B6B2C0C474200597973 /* ImageExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageExtension.swift; sourceTree = "<group>"; };
 		54073B7C2C0C564700597973 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		54073B822C0D906300597973 /* HomePopularFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePopularFeature.swift; sourceTree = "<group>"; };
-		54073B842C0D908200597973 /* NavigationBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationBarView.swift; sourceTree = "<group>"; };
-		54073B872C0D913800597973 /* NavigationBarFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationBarFeature.swift; sourceTree = "<group>"; };
+		54073B842C0D908200597973 /* HomeNavigationBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeNavigationBarView.swift; sourceTree = "<group>"; };
+		54073B872C0D913800597973 /* HomeNavigationBarFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeNavigationBarFeature.swift; sourceTree = "<group>"; };
 		54073B892C0D932D00597973 /* HomePopularView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePopularView.swift; sourceTree = "<group>"; };
 		54073B8B2C0D98E400597973 /* ReviewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewCell.swift; sourceTree = "<group>"; };
 		540BE9AF2C22C607009180AE /* ReviewDetailFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDetailFeature.swift; sourceTree = "<group>"; };
@@ -268,8 +268,8 @@
 		54073B862C0D90B400597973 /* NavigationBar */ = {
 			isa = PBXGroup;
 			children = (
-				54073B842C0D908200597973 /* NavigationBarView.swift */,
-				54073B872C0D913800597973 /* NavigationBarFeature.swift */,
+				54073B842C0D908200597973 /* HomeNavigationBarView.swift */,
+				54073B872C0D913800597973 /* HomeNavigationBarFeature.swift */,
 			);
 			path = NavigationBar;
 			sourceTree = "<group>";
@@ -813,15 +813,14 @@
 				549B1F912C0607C7005C9432 /* ContentView.swift in Sources */,
 				A6F5E6D12C2065750053C2E8 /* LoginView.swift in Sources */,
 				54DF6D992C1D61140031E95B /* HomeCheffiPlaceFeature.swift in Sources */,
-				A6F5E6D12C2065750053C2E8 /* LoginView.swift in Sources */,
-				54073B852C0D908200597973 /* NavigationBarView.swift in Sources */,
+				54073B852C0D908200597973 /* HomeNavigationBarView.swift in Sources */,
 				A6F5E6FB2C280AD00053C2E8 /* RestRouter+Path.swift in Sources */,
 				A6F5E6FE2C284D350053C2E8 /* TokenStorageEventMonitor.swift in Sources */,
 				A61FC3CF2C3D68E200C732C6 /* DataRequest+Response.swift in Sources */,
 				549B1F8F2C0607C7005C9432 /* CheffiApp.swift in Sources */,
 				A6DC44182C5C98E200423B90 /* OtherProfileModel.swift in Sources */,
 				540BE9B42C231036009180AE /* WriterRow.swift in Sources */,
-				54073B882C0D913800597973 /* NavigationBarFeature.swift in Sources */,
+				54073B882C0D913800597973 /* HomeNavigationBarFeature.swift in Sources */,
 				A670024E2C5CA61E00B7F336 /* URLParameterEncoding.swift in Sources */,
 				5419304B2C3D497D0080CA57 /* AllReviewFeature.swift in Sources */,
 				543F0AE42C10263100DFBDB1 /* HomeCheffiStoryView.swift in Sources */,

--- a/Cheffi/Module/Component/Extensions/ViewExtension.swift
+++ b/Cheffi/Module/Component/Extensions/ViewExtension.swift
@@ -29,6 +29,10 @@ extension View {
     }
     
     func onFirstAppear(_ action: @escaping () async -> Void) -> some View {
-           modifier(FirstAppearModifer(action))
-       }
+        modifier(FirstAppearModifer(action))
+    }
+    
+    func lineHeight(_ height: CGFloat, fontHeight: CGFloat) -> some View {
+        modifier(LineHeightModifier(lineHeight: height, fontHeight: fontHeight))
+    }
 }

--- a/Cheffi/Module/Component/Models/ReviewDetailModel.swift
+++ b/Cheffi/Module/Component/Models/ReviewDetailModel.swift
@@ -41,6 +41,64 @@ struct ReviewDetailModel: Codable, Equatable {
         case photos
         case menus
     }
+    
+    static let dummy: ReviewDetailModel = .init(
+    id: 1,
+    title: "태초동에 생긴 맛집!",
+    text: "초밥 태초세트 추천해요",
+    bookmarked: false,
+    ratedByUser: false,
+    ratingType: "GOOD",
+    createdDate: "2024-09-25T18:57:17.865Z",
+    timeLeftToLock: 86399751,
+    matchedTagNum: 3,
+    restaurant: Restaurant(
+        id: 3,
+        name: "을밀대",
+        address: Address(
+            province: "서울특별시",
+            city: "양천구",
+            roadName: "숭문길 24",
+            fullLotNumberAddress: "서울시 마포구 염리동 111",
+            fullRoadNameAddress: "서울시 마포구 숭문길 24"
+        ),
+        registered: true
+    ),
+    writer: Writer(
+        id: 1,
+        nickname: "닉네임1234",
+        photo: PhotoInfo(
+            url: "https://www~~~.com",
+            width: 320,
+            height: 320
+        ),
+        introduction: "안녕하세요, 리뷰 작성자입니다.",
+        writtenByViewer: false
+    ),
+    ratings: Ratings(
+        good: 0,
+        average: 0,
+        bad: 0
+    ),
+    photos: [
+        Photo(
+            id: 1,
+            order: 1,
+            photo: PhotoInfo(
+                url: "https://www~~~.com",
+                width: 320,
+                height: 320
+            )
+            )
+    ],
+    menus: [
+        Menu(
+            name: "곱창 전골",
+            price: 80000,
+            description: "string"
+        )
+    ]
+    )
 }
 
 

--- a/Cheffi/Module/Component/Util/LineHeightModifier.swift
+++ b/Cheffi/Module/Component/Util/LineHeightModifier.swift
@@ -1,0 +1,18 @@
+//
+//  LineHeightModifier.swift
+//  Cheffi
+//
+//  Created by 권승용 on 9/24/24.
+//
+import SwiftUI
+
+struct LineHeightModifier: ViewModifier {
+    let lineHeight: CGFloat
+    let fontHeight: CGFloat
+    
+    public func body(content: Content) -> some View {
+        content
+            .lineSpacing(lineHeight - fontHeight)
+            .padding(.vertical, (lineHeight - fontHeight) / 2)
+    }
+}

--- a/Cheffi/Module/Feature/AllReviewView/AllReviewView.swift
+++ b/Cheffi/Module/Feature/AllReviewView/AllReviewView.swift
@@ -27,7 +27,7 @@ struct AllReviewView: View {
     var body: some View {
         WithPerceptionTracking {
             VStack(spacing: 0) {
-                NavigationBarView(type: .back)
+                HomeNavigationBarView(type: .back)
                     .onTapGesture {
                         dismiss()
                     }

--- a/Cheffi/Module/Feature/Home/CheffiPlace/HomeCheffiPlaceView.swift
+++ b/Cheffi/Module/Feature/Home/CheffiPlace/HomeCheffiPlaceView.swift
@@ -91,8 +91,8 @@ struct HomeCheffiPlaceView: View {
                         ScrollViewReader { proxy in
                             ScrollView(.horizontal, showsIndicators: false) {
                                 HStack(spacing: 0) {
+                                    WithPerceptionTracking {
                                     ForEach(0..<store.state.tags.count, id: \.self) { index in
-                                        WithPerceptionTracking {
                                             VStack {
                                                 Text(store.state.tags[index].name)
                                                     .foregroundColor(selectedTab == index ? Color.primary : Color.grey5)

--- a/Cheffi/Module/Feature/Home/CheffiPlace/HomeCheffiPlaceView.swift
+++ b/Cheffi/Module/Feature/Home/CheffiPlace/HomeCheffiPlaceView.swift
@@ -27,101 +27,11 @@ struct HomeCheffiPlaceView: View {
         WithPerceptionTracking {
             LazyVStack(alignment: .leading, spacing: 0, pinnedViews: [.sectionHeaders]) {
                 Section(content: {
-                    VStack(spacing: 0) {
-                        TabView(selection: $selectedTab) {
-                            ForEach(0..<store.state.tags.count, id: \.self) { index in
-                                WithPerceptionTracking {
-                                    let tagId = store.state.tags[index].id
-                                    if let reviews = store.state.cheffiPlaceReviews[tagId], !reviews.isEmpty {
-                                        ScrollView(showsIndicators: false) {
-                                            LazyVGrid(columns: columns, spacing: 24) {
-                                                ForEach(reviews, id: \.id) { review in
-                                                    ReviewCell(review: review, type: .small)
-                                                }
-                                            }
-                                            .padding(.horizontal, 16)
-                                            .tag(index)
-                                        }
-                                    } else {
-                                        VStack(alignment: .center, spacing: 0) {
-                                            Image(name: Home.homeEmpty)
-                                                .padding(.bottom, 12)
-                                            Text("아직 주변의 \(store.state.tags[index].name) 맛집 리뷰가 없어요\n먼저 주변 아는 맛집을 소개해주세요!")
-                                                .font(.suit(.medium, 14))
-                                                .foregroundStyle(Color.grey6)
-                                                .padding(.bottom, 18)
-                                                .multilineTextAlignment(.center)
-                                            Text("맛집 직접 등록하기")
-                                                .font(.suit(.semiBold, 15))
-                                                .foregroundStyle(Color.primary)
-                                                .padding(.horizontal, 14)
-                                                .padding(.vertical, 9)
-                                                .background(Color.background)
-                                                .clipShape(.rect(cornerRadius: 10))
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    .frame(height: tabViewHeight)
-                    .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never)) // TODO: Nested ScrollView 스크롤 버그 수정하기
+                    tabView
                 }, header: {
                     VStack(alignment: .leading, spacing: 0) {
-                        HStack(spacing: 8) {
-                            Text("쉐피들의 인정 맛집")
-                                .foregroundStyle(Color.black)
-                                .font(.suit(.bold, 20))
-                            Image(name: Common.info)
-                                .overlay(
-                                    Group {
-                                        if store.state.showTooltip {
-                                            Image(name: Home.placeTooltip)
-                                                .offset(x: -60, y: 50)
-                                        }
-                                    }
-                                )
-                                .onTapGesture {
-                                    store.send(.toolTipTapped)
-                                }
-                        }
-                        .zIndex(2)
-                        .padding(.leading, 16)
-                        .padding(.bottom, 24)
-                        ScrollViewReader { proxy in
-                            ScrollView(.horizontal, showsIndicators: false) {
-                                HStack(spacing: 0) {
-                                    WithPerceptionTracking {
-                                    ForEach(0..<store.state.tags.count, id: \.self) { index in
-                                            VStack {
-                                                Text(store.state.tags[index].name)
-                                                    .foregroundColor(selectedTab == index ? Color.primary : Color.grey5)
-                                                    .font(.suit(.bold, 15))
-                                                    .frame(maxWidth: .infinity)
-                                                    .padding(EdgeInsets(top: 10, leading: 16, bottom: 8, trailing: 16))
-                                                    .onTapGesture {
-                                                        selectedTab = index
-                                                    }
-                                                Rectangle()
-                                                    .frame(height: 2)
-                                                    .foregroundColor(selectedTab == index ? .red : .clear)
-                                                    .layoutPriority(1)
-                                            }
-                                            .id(index)
-                                            .onChange(of: selectedTab) { index in
-                                                withAnimation {
-                                                    proxy.scrollTo(index, anchor: .center)
-                                                }
-                                                store.send(.requestCheffiPlace(tagId: (store.state.tags[index].id)))
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        .zIndex(1)
-                        .padding(.horizontal, 16)
-                        
+                        header
+                        categoryScroll
                         Color.grey05.frame(height: 2).offset(y: -2)
                             .padding(.bottom, 12)
                     }
@@ -134,10 +44,138 @@ struct HomeCheffiPlaceView: View {
             }
         }
     }
+    
+    private var header: some View {
+        HStack(spacing: 8) {
+            Text("쉐피들의 인정 맛집")
+                .foregroundStyle(Color.black)
+                .font(.suit(.bold, 20))
+            Image(name: Common.info)
+                .overlay(
+                    Group {
+                        if store.state.showTooltip {
+                            Image(name: Home.placeTooltip)
+                                .offset(x: -60, y: 50)
+                        }
+                    }
+                )
+                .onTapGesture {
+                    store.send(.toolTipTapped)
+                }
+        }
+        .zIndex(2)
+        .padding(.leading, 16)
+        .padding(.bottom, 24)
+    }
+    
+    private var categoryScroll: some View {
+        ScrollViewReader { proxy in
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 0) {
+                    WithPerceptionTracking {
+                        ForEach(0..<store.state.tags.count, id: \.self) { index in
+                            VStack {
+                                Text(store.state.tags[index].name)
+                                    .foregroundColor(selectedTab == index ? Color.primary : Color.grey5)
+                                    .font(.suit(.bold, 15))
+                                    .frame(maxWidth: .infinity)
+                                    .padding(EdgeInsets(top: 10, leading: 16, bottom: 8, trailing: 16))
+                                    .onTapGesture {
+                                        selectedTab = index
+                                    }
+                                Rectangle()
+                                    .frame(height: 2)
+                                    .foregroundColor(selectedTab == index ? .red : .clear)
+                                    .layoutPriority(1)
+                            }
+                            .id(index)
+                            .onChange(of: selectedTab) { index in
+                                withAnimation {
+                                    proxy.scrollTo(index, anchor: .center)
+                                }
+                                store.send(.requestCheffiPlace(tagId: (store.state.tags[index].id)))
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .zIndex(1)
+        .padding(.horizontal, 16)
+    }
+    
+    private var tabView: some View {
+        VStack(spacing: 0) {
+            TabView(selection: $selectedTab) {
+                ForEach(0..<store.state.tags.count, id: \.self) { index in
+                    WithPerceptionTracking {
+                        let tagId = store.state.tags[index].id
+                        if let reviews = store.state.cheffiPlaceReviews[tagId], !reviews.isEmpty {
+                            ScrollView(showsIndicators: false) {
+                                LazyVGrid(columns: columns, spacing: 24) {
+                                    ForEach(reviews, id: \.id) { review in
+                                        ReviewCell(review: review, type: .small)
+                                    }
+                                }
+                                .padding(.horizontal, 16)
+                                .tag(index)
+                            }
+                        } else {
+                            VStack(alignment: .center, spacing: 0) {
+                                Image(name: Home.homeEmpty)
+                                    .padding(.bottom, 12)
+                                Text("아직 주변의 \(store.state.tags[index].name) 맛집 리뷰가 없어요\n먼저 주변 아는 맛집을 소개해주세요!")
+                                    .font(.suit(.medium, 14))
+                                    .foregroundStyle(Color.grey6)
+                                    .padding(.bottom, 18)
+                                    .multilineTextAlignment(.center)
+                                Text("맛집 직접 등록하기")
+                                    .font(.suit(.semiBold, 15))
+                                    .foregroundStyle(Color.primary)
+                                    .padding(.horizontal, 14)
+                                    .padding(.vertical, 9)
+                                    .background(Color.background)
+                                    .clipShape(.rect(cornerRadius: 10))
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .frame(height: tabViewHeight)
+        .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never)) // TODO: Nested ScrollView 스크롤 버그 수정하기
+    }
 }
 
 #Preview {
-    HomeCheffiPlaceView()
+    let store: StoreOf<HomeCheffiPlaceFeature> = StoreOf<HomeCheffiPlaceFeature>(
+        initialState: HomeCheffiPlaceFeature.State(
+            tags: [
+                TagsModel(
+                    id: 0,
+                    name: "한식",
+                    type: "테스트"
+                ),
+                TagsModel(
+                    id: 1,
+                    name: "일식",
+                    type: "테스트"
+                ),
+                TagsModel(
+                    id: 2,
+                    name: "양식",
+                    type: "테스트"
+                )
+            ],
+            cheffiPlaceReviews: [
+                0: [ReviewModel.dummyData],
+                1: [ReviewModel.dummyData, ReviewModel.dummyData],
+            ]
+        )
+    ) {
+        HomeCheffiPlaceFeature()
+    }
+    HomeCheffiPlaceView(store: store)
 }
 
 struct TagType {

--- a/Cheffi/Module/Feature/Home/CheffiStory/HomeCheffiStoryView.swift
+++ b/Cheffi/Module/Feature/Home/CheffiStory/HomeCheffiStoryView.swift
@@ -40,109 +40,122 @@ struct HomeCheffiStoryView: View {
     
     var body: some View {
         WithPerceptionTracking {
-            VStack {
-                HStack {
-                    Text("음식, 분위기 맛\n나와 비슷한 쉐피들의 이야기")
-                        .foregroundStyle(.black)
-                        .font(.suit(.bold, 20))
-                        .padding(.bottom, 16)
-                    Spacer()
-                }
-                .padding(.horizontal, 16)
-                
-                ScrollView(.horizontal, showsIndicators: false) {
-                    HStack(spacing: 8) {
-                        ForEach($dummyCategories, id: \.self) { category in
-                            WithPerceptionTracking {
-                                Group {
-                                    if !store.state.selectedCategories.contains(category.wrappedValue) {
-                                        Text("\(category.wrappedValue)")
-                                            .foregroundStyle(Color.grey5)
-                                            .font(.suit(.semiBold, 15))
-                                            .padding(.horizontal, 16)
-                                            .padding(.vertical, 6)
-                                            .background(
-                                                RoundedRectangle(cornerRadius: 20)
-                                                    .strokeBorder(Color.grey1)
-                                            )
-                                        
-                                    } else {
-                                        Text("\(category.wrappedValue)")
-                                            .foregroundStyle(Color.white)
-                                            .font(.suit(.semiBold, 15))
-                                            .padding(.horizontal, 16)
-                                            .padding(.vertical, 6)
-                                            .background(Color.primary)
-                                            .clipShape(.rect(cornerRadius: 20))
-                                    }
-                                }
-                                .onTapGesture {
-                                    store.send(.categoryTapped(category.wrappedValue))
-                                }
-                            }
-                        }
-                    }
+            VStack(spacing: 0) {
+                header
                     .padding(.horizontal, 16)
-                }
-                .padding(.bottom, 16)
-                
-                TabView(selection: $currentpage) {
-                    ForEach(1...totalPage, id: \.self) { index in
-                        WithPerceptionTracking {
-                            VStack(spacing: 16) {
-                                let startIndex = (index - 1) * itemsPerPage
-                                let endIndex = min(startIndex + itemsPerPage, dummyDatas.count)
-                                let items = Array(dummyDatas[startIndex..<endIndex])
-                                ForEach(items, id: \.title) { item in
-                                    WithPerceptionTracking {
-                                        WriterRow(
-                                            photoUrl: String(),
-                                            title: item.title,
-                                            intro: item.intro,
-                                            isFollowed: item.isFollowed
-                                        )
-                                    }
-                                }
-                                .padding(.horizontal, 16)
-                                if items.count != 3 {
-                                    Spacer()
-                                }
-                            }
-                        }
-                    }
-                }
-                .frame(height: CGFloat(itemsPerPage * 64 + ((itemsPerPage - 1) * 16)))
-                .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
-                .animation(.easeInOut, value: currentpage)
-                .padding(.bottom, 16)
-                
-                // 탭뷰 페이징
-                HStack(spacing: 0) {
-                    Image(name: Home.previousPage)
-                        .padding(.trailing, 12)
-                        .onTapGesture {
-                            if currentpage != 1 {
-                                currentpage -= 1
-                            }
-                        }
-                    Text("\(currentpage)")
-                        .foregroundStyle(Color.black)
-                        .font(.suit(.medium, 16))
-                    Text(" / \(totalPage)")
-                        .foregroundStyle(Color.grey8)
-                        .font(.suit(.medium, 16))
-                    Image(name: Home.nextPage)
-                        .padding(.leading, 12)
-                        .onTapGesture {
-                            if currentpage != totalPage {
-                                currentpage += 1
-                            }
-                        }
-                }
+                chipButtons
+                    .padding(.bottom, 16)
+                tabView
+                paging
             }
             .onFirstAppear {
                 store.send(.onFirstAppear)
             }
+        }
+    }
+    
+    private var header: some View {
+        HStack {
+            Text("음식, 분위기 맛\n나와 비슷한 쉐피들의 이야기")
+                .foregroundStyle(.black)
+                .font(.suit(.bold, 20))
+                .padding(.bottom, 16)
+            Spacer()
+        }
+    }
+    
+    private var chipButtons: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach($dummyCategories, id: \.self) { category in
+                    WithPerceptionTracking {
+                        Group {
+                            if !store.state.selectedCategories.contains(category.wrappedValue) {
+                                Text("\(category.wrappedValue)")
+                                    .foregroundStyle(Color.grey5)
+                                    .font(.suit(.semiBold, 15))
+                                    .padding(.horizontal, 16)
+                                    .padding(.vertical, 6)
+                                    .background(
+                                        RoundedRectangle(cornerRadius: 20)
+                                            .strokeBorder(Color.grey1)
+                                    )
+                                
+                            } else {
+                                Text("\(category.wrappedValue)")
+                                    .foregroundStyle(Color.white)
+                                    .font(.suit(.semiBold, 15))
+                                    .padding(.horizontal, 16)
+                                    .padding(.vertical, 6)
+                                    .background(Color.primary)
+                                    .clipShape(.rect(cornerRadius: 20))
+                            }
+                        }
+                        .onTapGesture {
+                            store.send(.categoryTapped(category.wrappedValue))
+                        }
+                    }
+                }
+            }
+            .padding(.horizontal, 16)
+        }
+    }
+    
+    private var tabView: some View {
+        TabView(selection: $currentpage) {
+            ForEach(1...totalPage, id: \.self) { index in
+                WithPerceptionTracking {
+                    VStack(spacing: 16) {
+                        let startIndex = (index - 1) * itemsPerPage
+                        let endIndex = min(startIndex + itemsPerPage, dummyDatas.count)
+                        let items = Array(dummyDatas[startIndex..<endIndex])
+                        ForEach(items, id: \.title) { item in
+                            WithPerceptionTracking {
+                                WriterRow(
+                                    photoUrl: String(),
+                                    title: item.title,
+                                    intro: item.intro,
+                                    isFollowed: item.isFollowed
+                                )
+                            }
+                        }
+                        .padding(.horizontal, 16)
+                        if items.count != 3 {
+                            Spacer()
+                        }
+                    }
+                }
+            }
+        }
+        .frame(height: CGFloat(itemsPerPage * 64 + ((itemsPerPage - 1) * 16)))
+        .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
+        .animation(.easeInOut, value: currentpage)
+        .padding(.bottom, 16)
+    }
+    
+    private var paging: some View {
+        // 탭뷰 페이징
+        HStack(spacing: 0) {
+            Image(name: Home.previousPage)
+                .padding(.trailing, 12)
+                .onTapGesture {
+                    if currentpage != 1 {
+                        currentpage -= 1
+                    }
+                }
+            Text("\(currentpage)")
+                .foregroundStyle(Color.black)
+                .font(.suit(.medium, 16))
+            Text(" / \(totalPage)")
+                .foregroundStyle(Color.grey8)
+                .font(.suit(.medium, 16))
+            Image(name: Home.nextPage)
+                .padding(.leading, 12)
+                .onTapGesture {
+                    if currentpage != totalPage {
+                        currentpage += 1
+                    }
+                }
         }
     }
 }

--- a/Cheffi/Module/Feature/Home/HomeView.swift
+++ b/Cheffi/Module/Feature/Home/HomeView.swift
@@ -11,7 +11,7 @@ import ComposableArchitecture
 struct HomeView: View {
     var body: some View {
         VStack {
-            NavigationBarView(type: .normal)
+            HomeNavigationBarView(type: .normal)
             ScrollView(showsIndicators: false) {
                 // 인기 급등 맛집
                 HomePopularView()

--- a/Cheffi/Module/Feature/Home/NavigationBar/HomeNavigationBarFeature.swift
+++ b/Cheffi/Module/Feature/Home/NavigationBar/HomeNavigationBarFeature.swift
@@ -9,7 +9,7 @@ import Foundation
 import ComposableArchitecture
 
 @Reducer
-struct NavigationBarFeature {
+struct HomeNavigationBarFeature {
     
     @ObservableState
     struct State: Equatable {

--- a/Cheffi/Module/Feature/Home/NavigationBar/HomeNavigationBarView.swift
+++ b/Cheffi/Module/Feature/Home/NavigationBar/HomeNavigationBarView.swift
@@ -14,11 +14,11 @@ enum HomeNavigationType {
 }
 
 // TODO: 위치에 따른 네비게이션 타이틀 변경 및 각 버튼 기능동작
-struct NavigationBarView: View {
+struct HomeNavigationBarView: View {
     
-    @Perception.Bindable var store: StoreOf<NavigationBarFeature> = .init(
-        initialState: NavigationBarFeature.State()) {
-            NavigationBarFeature()
+    @Perception.Bindable var store: StoreOf<HomeNavigationBarFeature> = .init(
+        initialState: HomeNavigationBarFeature.State()) {
+            HomeNavigationBarFeature()
         }
     let type: HomeNavigationType
     
@@ -80,6 +80,6 @@ struct NavigationBarView: View {
 }
 
 #Preview {
-    NavigationBarView(type: .back)
-    NavigationBarView(type: .normal)
+    HomeNavigationBarView(type: .back)
+    HomeNavigationBarView(type: .normal)
 }

--- a/Cheffi/Module/Feature/Home/NavigationBar/NavigationBarView.swift
+++ b/Cheffi/Module/Feature/Home/NavigationBar/NavigationBarView.swift
@@ -13,6 +13,7 @@ enum HomeNavigationType {
     case back
 }
 
+// TODO: 위치에 따른 네비게이션 타이틀 변경 및 각 버튼 기능동작
 struct NavigationBarView: View {
     
     @Perception.Bindable var store: StoreOf<NavigationBarFeature> = .init(
@@ -55,7 +56,6 @@ struct NavigationBarView: View {
         }
     }
     
-    @ViewBuilder
     private func regionButton() -> some View {
         HStack(spacing: 8) {
             Text("서울특별시 성동구")
@@ -79,3 +79,7 @@ struct NavigationBarView: View {
     }
 }
 
+#Preview {
+    NavigationBarView(type: .back)
+    NavigationBarView(type: .normal)
+}

--- a/Cheffi/Module/Feature/Home/Popular/HomePopularView.swift
+++ b/Cheffi/Module/Feature/Home/Popular/HomePopularView.swift
@@ -26,7 +26,7 @@ struct HomePopularView: View {
     var body: some View {
         WithPerceptionTracking {
             NavigationStack(path: $store.scope(state: \.path, action: \.path)) {
-                VStack(alignment: .leading, spacing: 0) {
+                VStack(spacing: 0) {
                     headline
                     if store.popularReviews.count == 0 {
                         reviewEmpty
@@ -68,25 +68,33 @@ struct HomePopularView: View {
     }
     
     private var headline: some View {
-        Text("인기 급등 맛집")
-            .foregroundStyle(.black)
-            .font(.suit(.bold, 20))
-            .padding(.leading, 16)
+        HStack {
+            Text("인기 급등 맛집")
+                .foregroundStyle(.black)
+                .font(.suit(.bold, 20))
+                .lineHeight(22, fontHeight: 20)
+                .padding(.leading, 16)
+            Spacer()
+        }
     }
     
     private var reviewEmpty: some View {
         VStack(alignment: .center, spacing: 0) {
             Image(name: Home.homeEmpty)
+                .resizable()
+                .scaledToFit()
+                .frame(maxWidth: .infinity)
                 .padding(.bottom, 12)
-            // TODO: linehgight 수정 필요
             Text("아직 주변의 맛집 리뷰가 없어요\n먼저 주변 아는 맛집을 소개해주세요!")
                 .font(.suit(.medium, 14))
                 .foregroundStyle(Color.grey6)
+                .lineHeight(22, fontHeight: 14)
                 .padding(.bottom, 18)
                 .multilineTextAlignment(.center)
             Text("맛집 직접 등록하기")
                 .font(.suit(.semiBold, 15))
                 .foregroundStyle(Color.primary)
+                .lineHeight(22, fontHeight: 15)
                 .padding(.horizontal, 14)
                 .padding(.vertical, 9)
                 .background(Color.background)

--- a/Cheffi/Module/Feature/Home/Popular/HomePopularView.swift
+++ b/Cheffi/Module/Feature/Home/Popular/HomePopularView.swift
@@ -27,151 +27,18 @@ struct HomePopularView: View {
         WithPerceptionTracking {
             NavigationStack(path: $store.scope(state: \.path, action: \.path)) {
                 VStack(alignment: .leading, spacing: 0) {
-                    Text("인기 급등 맛집")
-                        .foregroundStyle(.black)
-                        .font(.suit(.bold, 20))
-                        .padding(.bottom, 16)
-                        .padding(.leading, 16)
+                    headline
                     if store.popularReviews.count == 0 {
-                        VStack(alignment: .center, spacing: 0) {
-                            Image(name: Home.homeEmpty)
-                                .padding(.bottom, 12)
-                            Text("아직 주변의 맛집 리뷰가 없어요\n먼저 주변 아는 맛집을 소개해주세요!")
-                                .font(.suit(.medium, 14))
-                                .foregroundStyle(Color.grey6)
-                                .padding(.bottom, 18)
-                                .multilineTextAlignment(.center)
-                            Text("맛집 직접 등록하기")
-                                .font(.suit(.semiBold, 15))
-                                .foregroundStyle(Color.primary)
-                                .padding(.horizontal, 14)
-                                .padding(.vertical, 9)
-                                .background(Color.background)
-                                .clipShape(.rect(cornerRadius: 10))
-                        }
+                        reviewEmpty
+                            .padding(.top, 40)
                     } else {
-                        VStack(alignment: .leading, spacing: 0) {
-                            HStack(spacing: 0) {
-                                Image(name: Common.clock)
-                                Text(store.remainTime.toHourMinuteSecond())
-                                    .foregroundStyle(Color.primary)
-                                    .font(.suit(.bold, 18))
-                                Text("초 뒤에")
-                                    .foregroundStyle(.black)
-                                    .font(.suit(.bold, 18))
-                            }
-                            HStack(spacing: 4) {
-                                Text("인기 급등 맛집이 변경돼요.")
-                                    .foregroundStyle(Color.black)
-                                    .font(.suit(.regular, 18))
-                                Image(name: Common.info)
-                                    .overlay(
-                                        Group {
-                                            if store.state.showTooltip {
-                                                Image(name: Home.popularTooptip)
-                                                    .offset(x: -60, y: 50)
-                                            }
-                                        }
-                                    )
-                                    .onTapGesture {
-                                        store.send(.toolTipTapped)
-                                    }
-                                Spacer()
-                                NavigationLink(state: HomePopularFeature.Path.State.moveToAllReviewView(
-                                    .init(popularReviews: store.popularReviews, remainTime: store.remainTime)
-                                )) {
-                                    HStack {
-                                        Text("전체보기")
-                                            .foregroundStyle(Color.grey6)
-                                            .font(.suit(.medium, 14))
-                                        Image(name: Common.rightArrow)
-                                            .resizable()
-                                            .renderingMode(.template)
-                                            .frame(width: 16, height: 16)
-                                            .foregroundStyle(Color.grey6)
-                                    }
-                                }
-                            }
-                        }
-                        .zIndex(1)
-                        .padding(.horizontal, 16)
-                        .padding(.bottom, 24)
-                        
-                        TabView(selection: $currentpage) {
-                            ForEach(0..<store.totalPage, id: \.self) { index in
-                                WithPerceptionTracking {
-                                    VStack {
-                                        if index == 0 {
-                                            NavigationLink(
-                                                state: HomePopularFeature.Path.State.moveToReviewDetailView(.init(id: store.popularReviews[0].id))
-                                            ) {
-                                                ReviewCell(review: store.popularReviews[0], type: .medium)
-                                            }
-                                            LazyVGrid(columns: columns) {
-                                                if store.popularReviews.count-1 >= 1 {
-                                                    NavigationLink(
-                                                        state: HomePopularFeature.Path.State.moveToReviewDetailView(.init(id: store.popularReviews[1].id))
-                                                    ) {
-                                                        ReviewCell(review: store.popularReviews[1], type: .small)
-                                                    }
-                                                }
-                                                if store.popularReviews.count-1 >= 2 {
-                                                    NavigationLink(
-                                                        state: HomePopularFeature.Path.State.moveToReviewDetailView(.init(id: store.popularReviews[2].id))
-                                                    ) {
-                                                        ReviewCell(review: store.popularReviews[2], type: .small)
-                                                    }
-                                                }
-                                            }
-                                        } else {
-                                            LazyVGrid(columns: columns) {
-                                                ForEach(0..<4) { offset in
-                                                    let reviewIndex = 3 + (index - 1) * 4 + offset
-                                                    if store.popularReviews.count-1 >= reviewIndex {
-                                                        NavigationLink(
-                                                            state: HomePopularFeature.Path.State.moveToReviewDetailView(.init(id: store.popularReviews[reviewIndex].id))
-                                                        ) {
-                                                            ReviewCell(review: store.popularReviews[reviewIndex], type: .small)
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                    .padding(.horizontal, 16)
-                                    .tag(index + 1)
-                                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-                                }
-                            }
-                        }
-                        .frame(height: store.popularReviews.count == 1 ? 270 : 573, alignment: .center)
-                        .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
-                        .animation(.easeInOut, value: currentpage)
-                        // 탭뷰 페이징
-                        HStack(spacing: 0) {
-                            Spacer()
-                            Image(name: Home.previousPage)
-                                .padding(.trailing, 12)
-                                .onTapGesture {
-                                    if currentpage != 1 {
-                                        currentpage -= 1
-                                    }
-                                }
-                            Text("\(currentpage)")
-                                .foregroundStyle(Color.black)
-                                .font(.suit(.medium, 16))
-                            Text(" / \(store.state.totalPage)")
-                                .foregroundStyle(Color.grey8)
-                                .font(.suit(.medium, 16))
-                            Image(name: Home.nextPage)
-                                .padding(.leading, 12)
-                                .onTapGesture {
-                                    if currentpage != store.state.totalPage {
-                                        currentpage += 1
-                                    }
-                                }
-                            Spacer()
-                        }
+                        timeIndicator
+                            .zIndex(1)
+                            .padding(.horizontal, 16)
+                            .padding(.bottom, 24)
+                            .padding(.top, 16)
+                        tabView
+                        paging
                     }
                 }
                 .onChange(of: scenePhase) { state in
@@ -197,6 +64,167 @@ struct HomePopularView: View {
                     }
                 }
             }
+        }
+    }
+    
+    private var headline: some View {
+        Text("인기 급등 맛집")
+            .foregroundStyle(.black)
+            .font(.suit(.bold, 20))
+                    .padding(.leading, 16)
+    }
+    
+    private var reviewEmpty: some View {
+        VStack(alignment: .center, spacing: 0) {
+            Image(name: Home.homeEmpty)
+                .padding(.bottom, 12)
+            // TODO: linehgight 수정 필요
+            Text("아직 주변의 맛집 리뷰가 없어요\n먼저 주변 아는 맛집을 소개해주세요!")
+                .font(.suit(.medium, 14))
+                .foregroundStyle(Color.grey6)
+                .padding(.bottom, 18)
+                .multilineTextAlignment(.center)
+            Text("맛집 직접 등록하기")
+                .font(.suit(.semiBold, 15))
+                .foregroundStyle(Color.primary)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 9)
+                .background(Color.background)
+                .clipShape(.rect(cornerRadius: 10))
+        }
+    }
+    
+    private var timeIndicator: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 0) {
+                Image(name: Common.clock)
+                Text(store.remainTime.toHourMinuteSecond())
+                    .foregroundStyle(Color.primary)
+                    .font(.suit(.bold, 18))
+                Text("초 뒤에")
+                    .foregroundStyle(.black)
+                    .font(.suit(.bold, 18))
+            }
+            HStack(spacing: 4) {
+                Text("인기 급등 맛집이 변경돼요.")
+                    .foregroundStyle(Color.black)
+                    .font(.suit(.regular, 18))
+                Image(name: Common.info)
+                    .overlay(
+                        Group {
+                            if store.state.showTooltip {
+                                Image(name: Home.popularTooptip)
+                                    .offset(x: -60, y: 50)
+                            }
+                        }
+                    )
+                    .onTapGesture {
+                        // TODO: 다른 영역 탭 시에도 툴팁 사라지는 기능 구현 필요
+                        store.send(.toolTipTapped)
+                    }
+                Spacer()
+                NavigationLink(state: HomePopularFeature.Path.State.moveToAllReviewView(
+                    .init(popularReviews: store.popularReviews, remainTime: store.remainTime)
+                )) {
+                    HStack {
+                        // TODO: 전체보기 탭 했을 때 리뷰 전체보기 화면으로 네비게이션 기능 구현 필요
+                        Text("전체보기")
+                            .foregroundStyle(Color.grey6)
+                            .font(.suit(.medium, 14))
+                        Image(name: Common.rightArrow)
+                            .resizable()
+                            .renderingMode(.template)
+                            .frame(width: 16, height: 16)
+                            .foregroundStyle(Color.grey6)
+                    }
+                }
+            }
+        }
+    }
+    
+    private var tabView: some View {
+        TabView(selection: $currentpage) {
+            ForEach(0..<store.totalPage, id: \.self) { index in
+                WithPerceptionTracking {
+                    VStack {
+                        // 첫 페이지
+                        if index == 0 {
+                            NavigationLink(
+                                state: HomePopularFeature.Path.State.moveToReviewDetailView(.init(id: store.popularReviews[0].id))
+                            ) {
+                                ReviewCell(review: store.popularReviews[0], type: .medium)
+                            }
+                            // TODO: 일반 Grid로 변경 필요
+                            LazyVGrid(columns: columns) {
+                                if store.popularReviews.count-1 >= 1 {
+                                    NavigationLink(
+                                        state: HomePopularFeature.Path.State.moveToReviewDetailView(.init(id: store.popularReviews[1].id))
+                                    ) {
+                                        ReviewCell(review: store.popularReviews[1], type: .small)
+                                    }
+                                }
+                                if store.popularReviews.count-1 >= 2 {
+                                    NavigationLink(
+                                        state: HomePopularFeature.Path.State.moveToReviewDetailView(.init(id: store.popularReviews[2].id))
+                                    ) {
+                                        ReviewCell(review: store.popularReviews[2], type: .small)
+                                    }
+                                }
+                            }
+                        } else {
+                            // 이후 페이지
+                            LazyVGrid(columns: columns) {
+                                ForEach(0..<4) { offset in
+                                    WithPerceptionTracking {
+                                        let reviewIndex = 3 + (index - 1) * 4 + offset
+                                        if store.popularReviews.count-1 >= reviewIndex {
+                                            NavigationLink(
+                                                state: HomePopularFeature.Path.State.moveToReviewDetailView(.init(id: store.popularReviews[reviewIndex].id))
+                                            ) {
+                                                ReviewCell(review: store.popularReviews[reviewIndex], type: .small)
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    .padding(.horizontal, 16)
+                    .tag(index + 1)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+                }
+            }
+        }
+        .frame(height: store.popularReviews.count == 1 ? 270 : 573, alignment: .center)
+        .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
+        .animation(.easeInOut, value: currentpage)
+    }
+    
+    private var paging: some View {
+        // 탭뷰 페이징
+        HStack(spacing: 0) {
+            Spacer()
+            Image(name: Home.previousPage)
+                .padding(.trailing, 12)
+                .onTapGesture {
+                    if currentpage != 1 {
+                        currentpage -= 1
+                    }
+                }
+            Text("\(currentpage)")
+                .foregroundStyle(Color.black)
+                .font(.suit(.medium, 16))
+            Text(" / \(store.state.totalPage)")
+                .foregroundStyle(Color.grey8)
+                .font(.suit(.medium, 16))
+            Image(name: Home.nextPage)
+                .padding(.leading, 12)
+                .onTapGesture {
+                    if currentpage != store.state.totalPage {
+                        currentpage += 1
+                    }
+                }
+            Spacer()
         }
     }
 }

--- a/Cheffi/Module/Feature/Home/Popular/HomePopularView.swift
+++ b/Cheffi/Module/Feature/Home/Popular/HomePopularView.swift
@@ -71,7 +71,7 @@ struct HomePopularView: View {
         Text("인기 급등 맛집")
             .foregroundStyle(.black)
             .font(.suit(.bold, 20))
-                    .padding(.leading, 16)
+            .padding(.leading, 16)
     }
     
     private var reviewEmpty: some View {
@@ -227,4 +227,25 @@ struct HomePopularView: View {
             Spacer()
         }
     }
+}
+
+#Preview("without Reviews") {
+    HomePopularView()
+}
+
+#Preview("with Reviews") {
+    let store: StoreOf<HomePopularFeature> = StoreOf<HomePopularFeature>(
+        initialState: HomePopularFeature.State(
+            popularReviews: [
+                ReviewModel.dummyData,
+                ReviewModel.dummyData,
+                ReviewModel.dummyData,
+                ReviewModel.dummyData,
+                ReviewModel.dummyData,
+            ]
+        )
+    ) {
+        HomePopularFeature()
+    }
+    HomePopularView(store: store)
 }


### PR DESCRIPTION
## 🌁 Background
- 코드 분석 도중 가독성 향상을 위해 뷰를 작은 단위로 분리하는 리팩토링을 진행하였습니다.

## 👩‍💻 Contents
- 뷰를 이해하기 쉬운 단위로 나눠 계산 프로퍼티로 분리하였습니다.
```swift
 private var headline: some View {
      Text("인기 급등 맛집")
          .foregroundStyle(.black)
          .font(.suit(.bold, 20))
          .padding(.leading, 16)
 }
```
- Preview 활용을 위해 로그인 / 서버 통신 없이 Preview 화면을 제공할 수 있는 더미 데이터를 작성하였습니다.
- 현재는 ReviewDetailModel에 관해서만 작성하였고, 추후 각 모델마다 더미 데이터를 작성할 계획입니다.
- lineHeight 뷰 모디파이어를 작성하였습니다. lineSpacing과 fontSize를 통해 lineHeight를 적용합니다.
```swift
struct LineHeightModifier: ViewModifier {
    let lineHeight: CGFloat
    let fontHeight: CGFloat
    
    public func body(content: Content) -> some View {
        content
            .lineSpacing(lineHeight - fontHeight)
            .padding(.vertical, (lineHeight - fontHeight) / 2)
    }
}
```
- 디자인에서 fontSize와 lineHeight가 일치하지 않는 경우 해당 모디파이어를 활용하면 디자인과 일치하는 텍스트를 작성 가능합니다.
## 📝 Review Note
- Home 화면의 코드 구조를 살펴보았습니다. 홈, 리뷰, 리뷰 디테일까지 전반적인 뷰들이 잘 구현되어 있는 것을 확인했습니다.
- 앞으로 실제 네트워크 통신 / 기능 동작 구현을 하나씩 해 나갈 예정입니다.
