### PR TITLE
[REFACTOR] Colors Asset 추가를 통한 Color 코드 작업방식 개선

### DIFF
--- a/Cheffi.xcodeproj/project.pbxproj
+++ b/Cheffi.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		54F217AD2C2D2FDB00892DBD /* Photo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F217AC2C2D2FDB00892DBD /* Photo.swift */; };
 		54F217B22C2D685400892DBD /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 54F217B12C2D685400892DBD /* Kingfisher */; };
 		6040AAF52CA275FA0016338E /* LineHeightModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6040AAF42CA275F30016338E /* LineHeightModifier.swift */; };
+		A60FB02B2CBD065A00B0B4A1 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A60FB02A2CBD065A00B0B4A1 /* Colors.xcassets */; };
 		A611D9D12C187D6500ABF38C /* EndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = A611D9D02C187D6500ABF38C /* EndPoint.swift */; };
 		A611D9D32C187D7800ABF38C /* RestRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A611D9D22C187D7800ABF38C /* RestRouter.swift */; };
 		A611D9D52C187D8400ABF38C /* NetworkClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A611D9D42C187D8400ABF38C /* NetworkClient.swift */; };
@@ -80,8 +81,6 @@
 		A681E99E2C4FDF7D00B796AA /* TermsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A681E99D2C4FDF7D00B796AA /* TermsView.swift */; };
 		A681E9A02C4FDF8400B796AA /* TermsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = A681E99F2C4FDF8400B796AA /* TermsFeature.swift */; };
 		A681E9A22C53DD1700B796AA /* SignupTermsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A681E9A12C53DD1700B796AA /* SignupTermsModel.swift */; };
-		A681E99E2C4FDF7D00B796AA /* TermsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A681E99D2C4FDF7D00B796AA /* TermsView.swift */; };
-		A681E9A02C4FDF8400B796AA /* TermsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = A681E99F2C4FDF8400B796AA /* TermsFeature.swift */; };
 		A688B0AB2C29B68600E4E3A2 /* RestResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = A688B0AA2C29B68600E4E3A2 /* RestResponse.swift */; };
 		A688B0AD2C29B68E00E4E3A2 /* LoginKakaoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A688B0AC2C29B68E00E4E3A2 /* LoginKakaoModel.swift */; };
 		A688B0B02C29B6A800E4E3A2 /* Authority.swift in Sources */ = {isa = PBXBuildFile; fileRef = A688B0AF2C29B6A800E4E3A2 /* Authority.swift */; };
@@ -178,6 +177,7 @@
 		54F217AA2C2D2F1B00892DBD /* ReviewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewModel.swift; sourceTree = "<group>"; };
 		54F217AC2C2D2FDB00892DBD /* Photo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Photo.swift; sourceTree = "<group>"; };
 		6040AAF42CA275F30016338E /* LineHeightModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineHeightModifier.swift; sourceTree = "<group>"; };
+		A60FB02A2CBD065A00B0B4A1 /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
 		A611D9D02C187D6500ABF38C /* EndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndPoint.swift; sourceTree = "<group>"; };
 		A611D9D22C187D7800ABF38C /* RestRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestRouter.swift; sourceTree = "<group>"; };
 		A611D9D42C187D8400ABF38C /* NetworkClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkClient.swift; sourceTree = "<group>"; };
@@ -197,8 +197,6 @@
 		A678A4842C2C5F0800A3D16B /* Launch Screen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
 		A678A4872C2C632F00A3D16B /* LaunchScreenView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchScreenView.swift; sourceTree = "<group>"; };
 		A6801E592C417DDA00471691 /* LoginFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginFeature.swift; sourceTree = "<group>"; };
-		A681E99D2C4FDF7D00B796AA /* TermsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsView.swift; sourceTree = "<group>"; };
-		A681E99F2C4FDF8400B796AA /* TermsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsFeature.swift; sourceTree = "<group>"; };
 		A681E99D2C4FDF7D00B796AA /* TermsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsView.swift; sourceTree = "<group>"; };
 		A681E99F2C4FDF8400B796AA /* TermsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsFeature.swift; sourceTree = "<group>"; };
 		A681E9A12C53DD1700B796AA /* SignupTermsModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupTermsModel.swift; sourceTree = "<group>"; };
@@ -334,6 +332,7 @@
 			children = (
 				549B1FD62C061A68005C9432 /* Info.plist */,
 				549B1F922C0607C9005C9432 /* Assets.xcassets */,
+				A60FB02A2CBD065A00B0B4A1 /* Colors.xcassets */,
 				A678A4842C2C5F0800A3D16B /* Launch Screen.storyboard */,
 				A67677F82C1740790089A269 /* Environment */,
 				549B1FC72C0617C6005C9432 /* Fonts */,
@@ -787,6 +786,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A60FB02B2CBD065A00B0B4A1 /* Colors.xcassets in Resources */,
 				54588AD72C074CF9000DD5A9 /* SUIT-Bold.otf in Resources */,
 				54588AD82C074CF9000DD5A9 /* SUIT-Medium.otf in Resources */,
 				A678A4852C2C5F0800A3D16B /* Launch Screen.storyboard in Resources */,

--- a/Cheffi/Application/Resource/Colors.xcassets/Contents.json
+++ b/Cheffi/Application/Resource/Colors.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cheffi/Application/Resource/Colors.xcassets/G10.colorset/Contents.json
+++ b/Cheffi/Application/Resource/Colors.xcassets/G10.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF5",
+          "green" : "0xF5",
+          "red" : "0xF5"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cheffi/Application/Resource/Colors.xcassets/G100.colorset/Contents.json
+++ b/Cheffi/Application/Resource/Colors.xcassets/G100.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x0A",
+          "green" : "0x0A",
+          "red" : "0x0A"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cheffi/Application/Resource/Colors.xcassets/G20.colorset/Contents.json
+++ b/Cheffi/Application/Resource/Colors.xcassets/G20.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xEC",
+          "green" : "0xEC",
+          "red" : "0xEC"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cheffi/Application/Resource/Colors.xcassets/G30.colorset/Contents.json
+++ b/Cheffi/Application/Resource/Colors.xcassets/G30.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xD8",
+          "green" : "0xD8",
+          "red" : "0xD8"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cheffi/Application/Resource/Colors.xcassets/G40.colorset/Contents.json
+++ b/Cheffi/Application/Resource/Colors.xcassets/G40.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xC5",
+          "green" : "0xC5",
+          "red" : "0xC5"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cheffi/Application/Resource/Colors.xcassets/G50.colorset/Contents.json
+++ b/Cheffi/Application/Resource/Colors.xcassets/G50.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x9E",
+          "green" : "0x9E",
+          "red" : "0x9E"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cheffi/Application/Resource/Colors.xcassets/G60.colorset/Contents.json
+++ b/Cheffi/Application/Resource/Colors.xcassets/G60.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x80",
+          "green" : "0x80",
+          "red" : "0x80"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cheffi/Application/Resource/Colors.xcassets/G70.colorset/Contents.json
+++ b/Cheffi/Application/Resource/Colors.xcassets/G70.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x63",
+          "green" : "0x63",
+          "red" : "0x63"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cheffi/Application/Resource/Colors.xcassets/G80.colorset/Contents.json
+++ b/Cheffi/Application/Resource/Colors.xcassets/G80.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x45",
+          "green" : "0x45",
+          "red" : "0x45"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cheffi/Application/Resource/Colors.xcassets/G90.colorset/Contents.json
+++ b/Cheffi/Application/Resource/Colors.xcassets/G90.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x28",
+          "green" : "0x28",
+          "red" : "0x28"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cheffi/Application/Resource/Colors.xcassets/M10.colorset/Contents.json
+++ b/Cheffi/Application/Resource/Colors.xcassets/M10.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xBA",
+          "green" : "0xB5",
+          "red" : "0xF5"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cheffi/Application/Resource/Colors.xcassets/M100.colorset/Contents.json
+++ b/Cheffi/Application/Resource/Colors.xcassets/M100.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x51",
+          "green" : "0x44",
+          "red" : "0xEB"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cheffi/Application/Resource/Colors.xcassets/M20.colorset/Contents.json
+++ b/Cheffi/Application/Resource/Colors.xcassets/M20.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xAF",
+          "green" : "0xA9",
+          "red" : "0xF5"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cheffi/Application/Resource/Colors.xcassets/M30.colorset/Contents.json
+++ b/Cheffi/Application/Resource/Colors.xcassets/M30.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xA4",
+          "green" : "0x9D",
+          "red" : "0xF5"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cheffi/Application/Resource/Colors.xcassets/M40.colorset/Contents.json
+++ b/Cheffi/Application/Resource/Colors.xcassets/M40.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x99",
+          "green" : "0x90",
+          "red" : "0xF5"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cheffi/Application/Resource/Colors.xcassets/M50.colorset/Contents.json
+++ b/Cheffi/Application/Resource/Colors.xcassets/M50.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x8D",
+          "green" : "0x84",
+          "red" : "0xF5"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cheffi/Application/Resource/Colors.xcassets/M60.colorset/Contents.json
+++ b/Cheffi/Application/Resource/Colors.xcassets/M60.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x80",
+          "green" : "0x75",
+          "red" : "0xF0"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cheffi/Application/Resource/Colors.xcassets/M70.colorset/Contents.json
+++ b/Cheffi/Application/Resource/Colors.xcassets/M70.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x75",
+          "green" : "0x69",
+          "red" : "0xF0"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cheffi/Application/Resource/Colors.xcassets/M80.colorset/Contents.json
+++ b/Cheffi/Application/Resource/Colors.xcassets/M80.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x6A",
+          "green" : "0x5D",
+          "red" : "0xF0"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cheffi/Application/Resource/Colors.xcassets/M90.colorset/Contents.json
+++ b/Cheffi/Application/Resource/Colors.xcassets/M90.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x5D",
+          "green" : "0x50",
+          "red" : "0xEB"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cheffi/Application/Resource/Colors.xcassets/MS10.colorset/Contents.json
+++ b/Cheffi/Application/Resource/Colors.xcassets/MS10.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF4",
+          "green" : "0xF2",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cheffi/Application/Resource/Colors.xcassets/MS100.colorset/Contents.json
+++ b/Cheffi/Application/Resource/Colors.xcassets/MS100.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x2B",
+          "green" : "0x0A",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cheffi/Application/Resource/Colors.xcassets/MS20.colorset/Contents.json
+++ b/Cheffi/Application/Resource/Colors.xcassets/MS20.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xDC",
+          "green" : "0xD6",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cheffi/Application/Resource/Colors.xcassets/MS30.colorset/Contents.json
+++ b/Cheffi/Application/Resource/Colors.xcassets/MS30.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xC6",
+          "green" : "0xBD",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cheffi/Application/Resource/Colors.xcassets/MS40.colorset/Contents.json
+++ b/Cheffi/Application/Resource/Colors.xcassets/MS40.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xAF",
+          "green" : "0xA3",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cheffi/Application/Resource/Colors.xcassets/MS50.colorset/Contents.json
+++ b/Cheffi/Application/Resource/Colors.xcassets/MS50.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x99",
+          "green" : "0x8A",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cheffi/Application/Resource/Colors.xcassets/MS60.colorset/Contents.json
+++ b/Cheffi/Application/Resource/Colors.xcassets/MS60.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x83",
+          "green" : "0x70",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cheffi/Application/Resource/Colors.xcassets/MS70.colorset/Contents.json
+++ b/Cheffi/Application/Resource/Colors.xcassets/MS70.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x6D",
+          "green" : "0x57",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cheffi/Application/Resource/Colors.xcassets/MS80.colorset/Contents.json
+++ b/Cheffi/Application/Resource/Colors.xcassets/MS80.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x57",
+          "green" : "0x3D",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cheffi/Application/Resource/Colors.xcassets/MS90.colorset/Contents.json
+++ b/Cheffi/Application/Resource/Colors.xcassets/MS90.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x41",
+          "green" : "0x24",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cheffi/Application/Resource/Colors.xcassets/SB01.colorset/Contents.json
+++ b/Cheffi/Application/Resource/Colors.xcassets/SB01.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE1",
+          "green" : "0x72",
+          "red" : "0x39"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cheffi/Application/Resource/Colors.xcassets/SB02.colorset/Contents.json
+++ b/Cheffi/Application/Resource/Colors.xcassets/SB02.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xEB",
+          "green" : "0x7C",
+          "red" : "0x43"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cheffi/Application/Resource/Colors.xcassets/SG01.colorset/Contents.json
+++ b/Cheffi/Application/Resource/Colors.xcassets/SG01.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x85",
+          "green" : "0xDB",
+          "red" : "0x28"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cheffi/Application/Resource/Colors.xcassets/SR01.colorset/Contents.json
+++ b/Cheffi/Application/Resource/Colors.xcassets/SR01.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x31",
+          "green" : "0x22",
+          "red" : "0xD8"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cheffi/Application/Resource/Colors.xcassets/SR02.colorset/Contents.json
+++ b/Cheffi/Application/Resource/Colors.xcassets/SR02.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x4C",
+          "green" : "0x3D",
+          "red" : "0xF3"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cheffi/Module/Component/Extensions/ColorExtension.swift
+++ b/Cheffi/Module/Component/Extensions/ColorExtension.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 /*
  ex) Text("example")
-        .foregroundStyle(Color.primary)
+        .foregroundStyle(Color(hex: 0xEB4451)
  */
 
 extension Color {
@@ -19,41 +19,4 @@ extension Color {
         let blue = Double((hex & 0xff) >> 0) / 255.0
         self.init(.sRGB, red: red, green: green, blue: blue, opacity: opacity)
     }
-    
-    static let primary = Color(hex: 0xEB4351)
-    
-    static let sub1 = Color(hex: 0xFFBFC9)
-    static let sub2 = Color(hex: 0xFF8EA0)
-    
-    static let grey05 = Color(hex: 0xF5F5F5)
-    static let grey1 = Color(hex: 0xECECEC)
-    static let grey2 = Color(hex: 0xD9D9D9)
-    static let grey3 = Color(hex: 0xC5C5C5)
-    static let grey4 = Color(hex: 0xB1B1B1)
-    static let grey5 = Color(hex: 0x9E9E9E)
-    static let grey6 = Color(hex: 0x808080)
-    static let grey7 = Color(hex: 0x636363)
-    static let grey8 = Color(hex: 0x454545)
-    static let grey9 = Color(hex: 0x282828)
-    
-    static let black = Color(hex: 0x0A0A0A)
-    static let white = Color(hex: 0xFFFFFF)
-    
-    static let dimmed = Color(hex: 0x000000, opacity: 0.4)
-    static let alarm_bg = Color(hex: 0x707070, opacity: 0.9)
-    
-    static let background = Color(hex: 0xFFF2F4)
-    
-    static let `true` = Color(hex: 0x3972E1)
-    static let `false` = Color(hex: 0xD82231)
-    
-    static let good = Color(hex: 0x437CEB)
-    static let soso = Color(hex: 0x28DB85)
-    static let bad = Color(hex: 0xF33D4C)
-    
-    static let littletime = Color(hex: 0xF63E4D)
-    
-    static let heart = Color(hex: 0xF65A68)
-    
-    static let expiration = Color(hex: 0xE53746)
 }

--- a/Cheffi/Module/Component/Util/ToastMessage.swift
+++ b/Cheffi/Module/Component/Util/ToastMessage.swift
@@ -36,7 +36,7 @@ struct ToastMessage: ViewModifier {
                     if type == .normal {
                         Text(message)
                             .multilineTextAlignment(.center)
-                            .foregroundStyle(Color.white)
+                            .foregroundStyle(.white)
                             .font(.suit(.medium, 16))
                             .onAppear {
                                 dismissWork()
@@ -46,7 +46,7 @@ struct ToastMessage: ViewModifier {
                             Image(name: Common.check)
                             Text(message)
                                 .multilineTextAlignment(.center)
-                                .foregroundStyle(Color.white)
+                                .foregroundStyle(.white)
                                 .font(.suit(.medium, 16))
                                 .onAppear {
                                     dismissWork()
@@ -56,16 +56,16 @@ struct ToastMessage: ViewModifier {
                         HStack(spacing: 22) {
                             Text(message)
                                 .multilineTextAlignment(.center)
-                                .foregroundStyle(Color.white)
+                                .foregroundStyle(.white)
                                 .font(.suit(.medium, 16))
                                 .onAppear {
                                     dismissWork()
                                 }
                             Text("취소")
-                                .foregroundStyle(Color.grey7)
+                                .foregroundStyle(.g70)
                                 .font(.suit(.medium, 16))
                                 .padding(EdgeInsets(top: 5, leading: 17, bottom: 5, trailing: 17))
-                                .background(Color.grey05)
+                                .background(.g50)
                                 .clipShape(.rect(cornerRadius: 10))
                                 .onTapGesture {
                                     isShowing = false
@@ -78,7 +78,7 @@ struct ToastMessage: ViewModifier {
             }
             .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: 54)
             .padding(.horizontal, 12)
-            .background(Color.alarm_bg.opacity(0.9))
+            .background(Color(hex: 0x707070, opacity: 0.9))
             .cornerRadius(8)
         }
         .padding(.horizontal, 16)

--- a/Cheffi/Module/Component/View/ReviewCell.swift
+++ b/Cheffi/Module/Component/View/ReviewCell.swift
@@ -34,7 +34,7 @@ struct ReviewCell: View {
             ZStack(alignment: .topTrailing) {
                 Group {
                     if !review.active {
-                        Color.grey05
+                        Color.g50
                             .clipShape(.rect(cornerRadius: 8))
                         Image(name: Review.deletedImage)
                     } else {
@@ -43,7 +43,7 @@ struct ReviewCell: View {
                             KFImage(url)
                                 .resizable()
                         } else {
-                            Color.grey05
+                            Color.g50
                                 .clipShape(.rect(cornerRadius: 8))
                             Image(name: Review.deletedImage)
                         }
@@ -75,12 +75,12 @@ struct ReviewCell: View {
                             ? timeLeftToLock.toHourMinute()
                             : timeLeftToLock.toHourMinuteSecond()
                         )
-                        .foregroundStyle(timeLeftToLock >= 300 || timeLeftToLock == 0 ? Color.white : Color.expiration)
+                        .foregroundStyle(timeLeftToLock >= 300 || timeLeftToLock == 0 ? .white : Color(hex: 0xE53746))
                         .font(.suit(.semiBold, 14))
                     }
                     .padding(.vertical, 4)
                     .padding(.horizontal, 12)
-                    .background(Color.black.opacity(0.32))
+                    .background(.black.opacity(0.32))
                     .clipShape(.rect(cornerRadius: 20))
                     .padding([.top, .trailing], 10)
                     .opacity(review.active ? 1 : 0)
@@ -90,7 +90,7 @@ struct ReviewCell: View {
             VStack(alignment: .leading) {
                 HStack(alignment: .top) {
                     Text(review.active ? review.title : "삭제된 리뷰입니다.")
-                        .foregroundStyle(Color.black)
+                        .foregroundStyle(.black)
                         .font(.suit(.bold, 18))
                         .lineLimit(type == .small ? 2 : 1)
                     Spacer()
@@ -99,7 +99,7 @@ struct ReviewCell: View {
                 }
                 Spacer().frame(height: 8)
                 Text(review.text)
-                    .foregroundStyle(Color.grey6)
+                    .foregroundStyle(.g60)
                     .font(.suit(.regular, 15))
                     .lineLimit(type == .medium ? 1 : 2)
                     .hidden(!review.active)

--- a/Cheffi/Module/Component/View/WriterRow.swift
+++ b/Cheffi/Module/Component/View/WriterRow.swift
@@ -23,7 +23,7 @@ struct WriterRow: View {
                         .resizable()
                 } else {
                     // TODO: 이미지 불러오지 못했을 때 UI 요청
-                    Color.grey3
+                    Color.g30
                 }
             }
             .frame(width: 64, height: 64)
@@ -31,11 +31,11 @@ struct WriterRow: View {
             Spacer().frame(width: 12)
             VStack(alignment: .leading, spacing: 6) {
                 Text(title)
-                    .foregroundStyle(Color.black)
+                    .foregroundStyle(.black)
                     .font(.suit(.semiBold, 16))
                     .lineLimit(1)
                 Text(intro)
-                    .foregroundStyle(Color.grey5)
+                    .foregroundStyle(.g50)
                     .font(.suit(.regular, 12))
                     .lineLimit(2)
             }
@@ -46,19 +46,19 @@ struct WriterRow: View {
                     Text("팔로우")
                         .padding(.vertical, 6)
                         .padding(.horizontal, 20)
-                        .background(Color.black)
-                        .foregroundStyle(Color.white)
+                        .background(.black)
+                        .foregroundStyle(.white)
                         .font(.suit(.bold, 12))
                         .clipShape(.rect(cornerRadius: 8))
                 } else {
                     Text("팔로잉")
                         .padding(.vertical, 6)
                         .padding(.horizontal, 20)
-                        .foregroundStyle(Color.black)
+                        .foregroundStyle(.black)
                         .font(.suit(.bold, 12))
                         .background(
                             RoundedRectangle(cornerRadius: 8)
-                                .strokeBorder(Color.grey2)
+                                .strokeBorder(.g20)
                         )
                 }
             }

--- a/Cheffi/Module/Feature/AllReviewView/AllReviewView.swift
+++ b/Cheffi/Module/Feature/AllReviewView/AllReviewView.swift
@@ -36,7 +36,7 @@ struct AllReviewView: View {
                         HStack(spacing: 0) {
                             Image(name: Common.clock)
                             Text(store.remainTime.toHourMinuteSecond())
-                                .foregroundStyle(Color.primary)
+                                .foregroundStyle(.m100)
                                 .font(.suit(.bold, 18))
                             Text("초 뒤에")
                                 .foregroundStyle(.black)
@@ -44,7 +44,7 @@ struct AllReviewView: View {
                         }
                         HStack(spacing: 4) {
                             Text("인기 급등 맛집이 변경돼요.")
-                                .foregroundStyle(Color.black)
+                                .foregroundStyle(.black)
                                 .font(.suit(.regular, 18))
                             Image(name: Common.info)
                                 .overlay(

--- a/Cheffi/Module/Feature/Home/CheffiPlace/HomeCheffiPlaceView.swift
+++ b/Cheffi/Module/Feature/Home/CheffiPlace/HomeCheffiPlaceView.swift
@@ -32,10 +32,10 @@ struct HomeCheffiPlaceView: View {
                     VStack(alignment: .leading, spacing: 0) {
                         header
                         categoryScroll
-                        Color.grey05.frame(height: 2).offset(y: -2)
+                        Color.g50.frame(height: 2).offset(y: -2)
                             .padding(.bottom, 12)
                     }
-                    .background(Color.white)
+                    .background(.white)
                 })
             }
             .onFirstAppear {
@@ -76,7 +76,7 @@ struct HomeCheffiPlaceView: View {
                         ForEach(0..<store.state.tags.count, id: \.self) { index in
                             VStack {
                                 Text(store.state.tags[index].name)
-                                    .foregroundColor(selectedTab == index ? Color.primary : Color.grey5)
+                                    .foregroundColor(selectedTab == index ? .m100 : .g50)
                                     .font(.suit(.bold, 15))
                                     .frame(maxWidth: .infinity)
                                     .padding(EdgeInsets(top: 10, leading: 16, bottom: 8, trailing: 16))
@@ -126,15 +126,15 @@ struct HomeCheffiPlaceView: View {
                                     .padding(.bottom, 12)
                                 Text("아직 주변의 \(store.state.tags[index].name) 맛집 리뷰가 없어요\n먼저 주변 아는 맛집을 소개해주세요!")
                                     .font(.suit(.medium, 14))
-                                    .foregroundStyle(Color.grey6)
+                                    .foregroundStyle(.g60)
                                     .padding(.bottom, 18)
                                     .multilineTextAlignment(.center)
                                 Text("맛집 직접 등록하기")
                                     .font(.suit(.semiBold, 15))
-                                    .foregroundStyle(Color.primary)
+                                    .foregroundStyle(.m100)
                                     .padding(.horizontal, 14)
                                     .padding(.vertical, 9)
-                                    .background(Color.background)
+                                    .background(.ms10)
                                     .clipShape(.rect(cornerRadius: 10))
                             }
                         }
@@ -175,7 +175,7 @@ struct HomeCheffiPlaceView: View {
     ) {
         HomeCheffiPlaceFeature()
     }
-    HomeCheffiPlaceView(store: store)
+    return HomeCheffiPlaceView(store: store)
 }
 
 struct TagType {

--- a/Cheffi/Module/Feature/Home/CheffiStory/HomeCheffiStoryView.swift
+++ b/Cheffi/Module/Feature/Home/CheffiStory/HomeCheffiStoryView.swift
@@ -72,22 +72,22 @@ struct HomeCheffiStoryView: View {
                         Group {
                             if !store.state.selectedCategories.contains(category.wrappedValue) {
                                 Text("\(category.wrappedValue)")
-                                    .foregroundStyle(Color.grey5)
+                                    .foregroundStyle(.g50)
                                     .font(.suit(.semiBold, 15))
                                     .padding(.horizontal, 16)
                                     .padding(.vertical, 6)
                                     .background(
                                         RoundedRectangle(cornerRadius: 20)
-                                            .strokeBorder(Color.grey1)
+                                            .strokeBorder(.g10)
                                     )
                                 
                             } else {
                                 Text("\(category.wrappedValue)")
-                                    .foregroundStyle(Color.white)
+                                    .foregroundStyle(.white)
                                     .font(.suit(.semiBold, 15))
                                     .padding(.horizontal, 16)
                                     .padding(.vertical, 6)
-                                    .background(Color.primary)
+                                    .background(.m100)
                                     .clipShape(.rect(cornerRadius: 20))
                             }
                         }
@@ -144,10 +144,10 @@ struct HomeCheffiStoryView: View {
                     }
                 }
             Text("\(currentpage)")
-                .foregroundStyle(Color.black)
+                .foregroundStyle(.black)
                 .font(.suit(.medium, 16))
             Text(" / \(totalPage)")
-                .foregroundStyle(Color.grey8)
+                .foregroundStyle(.g80)
                 .font(.suit(.medium, 16))
             Image(name: Home.nextPage)
                 .padding(.leading, 12)

--- a/Cheffi/Module/Feature/Home/NavigationBar/HomeNavigationBarView.swift
+++ b/Cheffi/Module/Feature/Home/NavigationBar/HomeNavigationBarView.swift
@@ -79,7 +79,10 @@ struct HomeNavigationBarView: View {
     }
 }
 
-#Preview {
-    HomeNavigationBarView(type: .back)
-    HomeNavigationBarView(type: .normal)
+#Preview("back") {
+    return HomeNavigationBarView(type: .back)
+}
+
+#Preview("normal") {
+    return HomeNavigationBarView(type: .normal)
 }

--- a/Cheffi/Module/Feature/Home/Popular/HomePopularView.swift
+++ b/Cheffi/Module/Feature/Home/Popular/HomePopularView.swift
@@ -87,17 +87,17 @@ struct HomePopularView: View {
                 .padding(.bottom, 12)
             Text("아직 주변의 맛집 리뷰가 없어요\n먼저 주변 아는 맛집을 소개해주세요!")
                 .font(.suit(.medium, 14))
-                .foregroundStyle(Color.grey6)
+                .foregroundStyle(.g60)
                 .lineHeight(22, fontHeight: 14)
                 .padding(.bottom, 18)
                 .multilineTextAlignment(.center)
             Text("맛집 직접 등록하기")
                 .font(.suit(.semiBold, 15))
-                .foregroundStyle(Color.primary)
+                .foregroundStyle(.m100)
                 .lineHeight(22, fontHeight: 15)
                 .padding(.horizontal, 14)
                 .padding(.vertical, 9)
-                .background(Color.background)
+                .background(.ms10)
                 .clipShape(.rect(cornerRadius: 10))
         }
     }
@@ -107,7 +107,7 @@ struct HomePopularView: View {
             HStack(spacing: 0) {
                 Image(name: Common.clock)
                 Text(store.remainTime.toHourMinuteSecond())
-                    .foregroundStyle(Color.primary)
+                    .foregroundStyle(.m100)
                     .font(.suit(.bold, 18))
                 Text("초 뒤에")
                     .foregroundStyle(.black)
@@ -115,7 +115,7 @@ struct HomePopularView: View {
             }
             HStack(spacing: 4) {
                 Text("인기 급등 맛집이 변경돼요.")
-                    .foregroundStyle(Color.black)
+                    .foregroundStyle(.black)
                     .font(.suit(.regular, 18))
                 Image(name: Common.info)
                     .overlay(
@@ -137,13 +137,13 @@ struct HomePopularView: View {
                     HStack {
                         // TODO: 전체보기 탭 했을 때 리뷰 전체보기 화면으로 네비게이션 기능 구현 필요
                         Text("전체보기")
-                            .foregroundStyle(Color.grey6)
+                            .foregroundStyle(.g60)
                             .font(.suit(.medium, 14))
                         Image(name: Common.rightArrow)
                             .resizable()
                             .renderingMode(.template)
                             .frame(width: 16, height: 16)
-                            .foregroundStyle(Color.grey6)
+                            .foregroundStyle(.g60)
                     }
                 }
             }
@@ -220,10 +220,10 @@ struct HomePopularView: View {
                     }
                 }
             Text("\(currentpage)")
-                .foregroundStyle(Color.black)
+                .foregroundStyle(.black)
                 .font(.suit(.medium, 16))
             Text(" / \(store.state.totalPage)")
-                .foregroundStyle(Color.grey8)
+                .foregroundStyle(.g80)
                 .font(.suit(.medium, 16))
             Image(name: Home.nextPage)
                 .padding(.leading, 12)
@@ -255,5 +255,5 @@ struct HomePopularView: View {
     ) {
         HomePopularFeature()
     }
-    HomePopularView(store: store)
+    return HomePopularView(store: store)
 }

--- a/Cheffi/Module/Feature/LaunchScreen/LaunchScreenView.swift
+++ b/Cheffi/Module/Feature/LaunchScreen/LaunchScreenView.swift
@@ -15,7 +15,7 @@ struct LaunchScreenView: View {
     var body: some View {
         WithPerceptionTracking {
             ZStack {
-                Color.primary
+                Color.m100
                     .ignoresSafeArea()
                 
                 Image("launchScreenLogo")

--- a/Cheffi/Module/Feature/Main/MainTabView.swift
+++ b/Cheffi/Module/Feature/Main/MainTabView.swift
@@ -33,13 +33,13 @@ struct MainTabView: View {
                                     : type.tabItem.normalImage
                                     
                                     Text(type.tabItem.title)
-                                        .foregroundStyle(Color.grey4)
+                                        .foregroundStyle(.g40)
                                         .font(.suit(.regular, 12))
                                 }
                             }
                     }
                 }
-                .accentColor(Color.primary)
+                .accentColor(.m100)
             }
             .fullScreenCover(isPresented: $store.presentRegisterView.sending(\.toggleRegisterView)) {
                 Text("맛집등록 뷰")
@@ -57,8 +57,8 @@ struct MainTabView: View {
             }
             .onAppear {
                 let appearance = UITabBarAppearance()
-                appearance.backgroundImage = UIImage.borderForTabBar(color: Color.white)
-                appearance.shadowImage = UIImage.borderForTabBar(color: Color.grey1)
+                appearance.backgroundImage = UIImage.borderForTabBar(color: .white)
+                appearance.shadowImage = UIImage.borderForTabBar(color: .g10)
                 UITabBar.appearance().standardAppearance = appearance
                 UITabBar.appearance().scrollEdgeAppearance = appearance
             }

--- a/Cheffi/Module/Feature/Review/ReviewDetailView.swift
+++ b/Cheffi/Module/Feature/Review/ReviewDetailView.swift
@@ -62,7 +62,7 @@ struct ReviewDetailView: View {
                         }
                         .padding(.horizontal, 16)
                         .padding(.bottom, 10)
-                        .background(Color.white.opacity(navigationBarOpacity))
+                        .background(.white.opacity(navigationBarOpacity))
                         .zIndex(1)
                         
                         ScrollViewOffset(onOffsetChange: { offset in
@@ -79,7 +79,7 @@ struct ReviewDetailView: View {
                                                     .resizable()
                                             } else {
                                                 // TODO: 이미지 불러오지 못했을 때 UI 요청
-                                                Color.grey3
+                                                Color.g30
                                             }
                                         }
                                         .scaledToFill()
@@ -92,14 +92,14 @@ struct ReviewDetailView: View {
                                     Spacer()
                                     Text("취향 \(review.matchedTagNum ?? 0)개 일치")
                                         .font(.suit(.bold, 14))
-                                        .foregroundStyle(Color.white)
+                                        .foregroundStyle(.white)
                                         .padding(EdgeInsets(top: 4, leading: 12, bottom: 4, trailing: 12))
-                                        .background(Color.black.opacity(0.32))
+                                        .background(.black.opacity(0.32))
                                         .clipShape(.rect(cornerRadius: 20))
                                         .padding(.bottom, 5)
                                     Text(review.title)
                                         .font(.suit(.bold, 24))
-                                        .foregroundStyle(Color.white)
+                                        .foregroundStyle(.white)
                                         .lineLimit(2)
                                         .padding(.vertical, 5)
                                         .padding(.bottom, 3)
@@ -115,18 +115,18 @@ struct ReviewDetailView: View {
                                     HStack {
                                         Text(review.createdDate.timeAgo())
                                             .font(.suit(.medium, 14))
-                                            .foregroundStyle(Color.grey3)
+                                            .foregroundStyle(.g30)
                                         Spacer()
                                         HStack(spacing: 0) {
                                             Text("\(selection + 1)")
                                                 .font(.suit(.medium, 14))
-                                                .foregroundStyle(Color.white)
+                                                .foregroundStyle(.white)
                                             Text("/\(review.photos.count)")
                                                 .font(.suit(.medium, 14))
-                                                .foregroundStyle(Color.grey1)
+                                                .foregroundStyle(.g10)
                                         }
                                         .padding(EdgeInsets(top: 4, leading: 10, bottom: 4, trailing: 10))
-                                        .background(Color.black.opacity(0.32))
+                                        .background(.black.opacity(0.32))
                                         .clipShape(.rect(cornerRadius: 20))
                                     }
                                     .padding(.bottom, 16)
@@ -150,7 +150,7 @@ struct ReviewDetailView: View {
                                 HStack(alignment: .center) {
                                     Text(review.restaurant.name)
                                         .font(.suit(.bold, 24))
-                                        .foregroundStyle(Color.black)
+                                        .foregroundStyle(.black)
                                     Spacer()
                                     Image(name: Common.emptyHeart)
                                 }
@@ -158,26 +158,26 @@ struct ReviewDetailView: View {
                                 // 리뷰 본문
                                 Text(review.text)
                                     .font(.suit(.regular, 16))
-                                    .foregroundStyle(Color.grey8)
+                                    .foregroundStyle(.g80)
                                     .padding(.bottom, 32)
                                 // 메뉴
                                 if review.menus.count != 0 {
                                     VStack(alignment: .leading, spacing: 4) {
                                         Text("메뉴")
                                             .font(.suit(.bold, 18))
-                                            .foregroundStyle(Color.black)
+                                            .foregroundStyle(.black)
                                             .padding(.bottom, 8)
                                         ForEach(0..<review.menus.count, id: \.self) { index in
                                             HStack {
                                                 Text(review.menus[index].name)
                                                     .font(.suit(.regular, 16))
-                                                    .foregroundStyle(Color.grey8)
+                                                    .foregroundStyle(.g80)
                                                     .frame(width: (screenWidth - 32) * 0.58, alignment: .leading)
                                                     .lineLimit(1)
                                                 Spacer()
                                                 Text("\(review.menus[index].price)원")
                                                     .font(.suit(.medium, 16))
-                                                    .foregroundStyle(Color.grey7)
+                                                    .foregroundStyle(.g70)
                                                     .frame(width: (screenWidth - 32) * 0.36, alignment: .trailing)
                                                     .lineLimit(1)
                                             }
@@ -189,19 +189,19 @@ struct ReviewDetailView: View {
                                 VStack(alignment: .leading, spacing: 12) {
                                     Text("위치")
                                         .font(.suit(.bold, 18))
-                                        .foregroundStyle(Color.black)
+                                        .foregroundStyle(.black)
                                         .padding(.bottom, 6)
                                     HStack {
                                         Text(review.restaurant.address.fullRoadNameAddress)
                                             .font(.suit(.regular, 16))
-                                            .foregroundStyle(Color.grey8)
+                                            .foregroundStyle(.g80)
                                             .frame(width: (screenWidth - 32) * 0.88, alignment: .leading)
                                             .lineLimit(1)
                                         Spacer()
                                         Text("복사")
                                             .underline()
                                             .font(.suit(.regular, 14))
-                                            .foregroundStyle(Color.init(hex: 0x34AFF7))
+                                            .foregroundStyle(Color(hex: 0x34AFF7))
                                             .onTapGesture {
                                                 UIPasteboard.general.string = review.restaurant.address.fullRoadNameAddress
                                                 store.send(.toggleShowToast(true))
@@ -210,13 +210,13 @@ struct ReviewDetailView: View {
                                 }
                                 .padding(.bottom, 32)
                                 // 경계선
-                                Color.grey1.frame(height: 1)
+                                Color.g10.frame(height: 1)
                                     .padding(.bottom, 32)
                                 // 작성자
                                 VStack(alignment: .leading, spacing: 16) {
                                     Text("작성자")
                                         .font(.suit(.bold, 18))
-                                        .foregroundStyle(Color.black)
+                                        .foregroundStyle(.black)
                                         .padding(.bottom, 6)
                                     WriterRow(
                                         photoUrl: review.writer.photo.url,
@@ -230,7 +230,7 @@ struct ReviewDetailView: View {
                                 VStack(alignment: .leading, spacing: 16) {
                                     Text("이 식당 어떠셨나요?")
                                         .font(.suit(.bold, 18))
-                                        .foregroundStyle(Color.black)
+                                        .foregroundStyle(.black)
                                         .padding(.bottom, 12)
                                     HStack {
                                         Spacer()
@@ -238,37 +238,37 @@ struct ReviewDetailView: View {
                                             Image(name: Review.normalGood)
                                             Text("맛있어요")
                                                 .font(.suit(.regular, 12))
-                                                .foregroundStyle(Color.grey5)
+                                                .foregroundStyle(.g50)
                                             Text("\(review.ratings.good)")
                                                 .font(.suit(.regular, 15))
-                                                .foregroundStyle(Color.grey5)
+                                                .foregroundStyle(.g50)
                                         }
                                         Spacer()
                                         VStack(spacing: 8) {
                                             Image(name: Review.normalSoso)
                                             Text("평범해요")
                                                 .font(.suit(.regular, 12))
-                                                .foregroundStyle(Color.grey5)
+                                                .foregroundStyle(.g50)
                                             Text("\(review.ratings.average)")
                                                 .font(.suit(.regular, 15))
-                                                .foregroundStyle(Color.grey5)
+                                                .foregroundStyle(.g50)
                                         }
                                         Spacer()
                                         VStack(spacing: 8) {
                                             Image(name: Review.normalBad)
                                             Text("별로에요")
                                                 .font(.suit(.regular, 12))
-                                                .foregroundStyle(Color.grey5)
+                                                .foregroundStyle(.g50)
                                             Text("\(review.ratings.bad)")
                                                 .font(.suit(.regular, 15))
-                                                .foregroundStyle(Color.grey5)
+                                                .foregroundStyle(.g50)
                                         }
                                         Spacer()
                                     }
                                     .padding(.vertical, 16)
                                     .overlay(
                                         RoundedRectangle(cornerRadius: 16)
-                                            .stroke(Color.grey1, lineWidth: 1)
+                                            .stroke(.g10, lineWidth: 1)
                                     )
                                 }
                                 .padding(.bottom, 32)

--- a/Cheffi/Module/Feature/Terms/TermsView.swift
+++ b/Cheffi/Module/Feature/Terms/TermsView.swift
@@ -17,7 +17,7 @@ struct TermsView: View {
             VStack(alignment: .leading, spacing: 0) {
                 Text("약관에 동의해주세요")
                     .font(.suit(.semiBold, 22))
-                    .foregroundStyle(Color.grey9)
+                    .foregroundStyle(.g90)
                     .padding(.leading, 16)
                     .padding(.top, 68)
                 
@@ -37,7 +37,7 @@ struct TermsView: View {
                             
                             Text("약관 전체동의")
                                 .font(.suit(.semiBold, 18))
-                                .foregroundStyle(Color.grey9)
+                                .foregroundStyle(.g90)
                                 .padding(.leading, 18)
                         }
                     })
@@ -45,14 +45,14 @@ struct TermsView: View {
                     
                     Text("서비스 이용을 위해 다음의 약관에 모두 동의합니다.")
                         .font(.suit(.regular, 14))
-                        .foregroundStyle(Color.grey4)
+                        .foregroundStyle(.g40)
                         .padding(.top, 14)
                         .padding(.leading, 68)
                 }
                 .padding(.top, 38)
                 
                 Divider()
-                    .foregroundStyle(Color.grey05)
+                    .foregroundStyle(.g50)
                     .frame(height: 1)
                     .padding(.top, 16)
                 
@@ -73,7 +73,7 @@ struct TermsView: View {
                                 
                                 Text(terms.type.description)
                                     .font(.suit(.regular, 15))
-                                    .foregroundStyle(Color.grey9)
+                                    .foregroundStyle(.g90)
                                     .padding(.leading, 14)
                             }
                         })
@@ -89,7 +89,7 @@ struct TermsView: View {
                                     .resizable()
                                     .renderingMode(.template)
                                     .frame(width: 24, height: 24)
-                                    .foregroundStyle(Color.grey4)
+                                    .foregroundStyle(.g40)
                                     .padding(.trailing, 26)
                             })
                         }
@@ -110,16 +110,16 @@ struct TermsView: View {
                         RoundedRectangle(cornerRadius: 10)
                             .foregroundStyle(
                                 store.isNextEnabled
-                                ? Color.primary
-                                : Color.grey1
+                                ? .m100
+                                : .g10
                             )
                         
                         Text("다음")
                             .font(.suit(.semiBold, 18))
                             .foregroundStyle(
                                 store.isNextEnabled
-                                ? Color.white
-                                : Color.grey5
+                                ? .white
+                                : .g50
                             )
                     }
                 })


### PR DESCRIPTION
## 🌁 Background

기존 ColorsExtension에는 복합적인 문제가 존재했어요.

1. black, white, primary 색상은 Swift에서 기본적으로 제공하는 색상으로, 해당 색상을 사용할 경우 Preview가 동작하지 않는 문제
2. 각 색상의 아이덴티티를 나타내는 네이밍이 적용된건 좋지만, Color hex 값을 확인하고 적용하는 과정이 필수적임
3. Figma Color 디자인 가이드 네이밍과 Xcode Color 네이밍이 동일하지 않아 혼란스러움

## 📱 Screenshot
| Colors.assets |
|:--:|
| <img width="300" alt="스크린샷 2024-08-07 오후 9 09 12" src="https://github.com/user-attachments/assets/874e7139-5660-4b7f-97ad-3afc985124a3"> |

## 👩‍💻 Contents

Xcode 15에서는 DeveloperToolsSupport 프레임워크 덕분에, 추가한 Color 에셋이 곧장 ColorResource로 추가되고

<img width="300" alt="image" src="https://github.com/user-attachments/assets/f8ace967-d91f-47ca-a433-c09f2c75d77a">

GeneratedAssetSymbols.swift로 이동하면, 아래 코드를 볼 수 있어요.

```swift
// MARK: - Color Symbols -

@available(iOS 11.0, macOS 10.13, tvOS 11.0, *)
extension ColorResource {

    /// The "g10" asset catalog color resource.
    static let g10 = ColorResource(name: "g10", bundle: resourceBundle)

    /// The "g100" asset catalog color resource.
    static let g100 = ColorResource(name: "g100", bundle: resourceBundle)

    /// The "g20" asset catalog color resource.
    static let g20 = ColorResource(name: "g20", bundle: resourceBundle)

    /// The "g30" asset catalog color resource.
    static let g30 = ColorResource(name: "g30", bundle: resourceBundle)

    /// The "g40" asset catalog color resource.
    static let g40 = ColorResource(name: "g40", bundle: resourceBundle)

    ...
```

## 📝 Review Note

```swift
Text("Before")
    .foregroundStyle(Color.grey1)

Text("After")
    .foregroundStyle(.g10)
```

그리고, 암시적으로 Color를 생략할 수 있는 경우에는 생략하도록 수정하였습니다.
```swift
Text("Ex")
    //.foregroundStyle(Color.white) X
    .foregroundStyle(.white) O
```
